### PR TITLE
Moq data

### DIFF
--- a/Mutagen.Bethesda.Analyzers.Testing/AutoFixture/MoqDataAttribute.cs
+++ b/Mutagen.Bethesda.Analyzers.Testing/AutoFixture/MoqDataAttribute.cs
@@ -1,0 +1,32 @@
+﻿using AutoFixture;
+using AutoFixture.AutoMoq;
+using AutoFixture.Xunit2;
+using Mutagen.Bethesda;
+using Mutagen.Bethesda.Testing.AutoData;
+using Noggog.Testing.AutoFixture;
+
+namespace Mutagen.Bethesda.Analyzers.Testing.AutoFixture
+{
+    public class MoqDataAttribute : AutoDataAttribute
+    {
+        public MoqDataAttribute(
+            bool ConfigureMembers = false,
+            GameRelease Release = GameRelease.SkyrimSE,
+            bool UseMockFileSystem = true)
+            : base(() =>
+            {
+                var fixture = new Fixture();
+                fixture.Customize(new AutoMoqCustomization()
+                {
+                    ConfigureMembers = ConfigureMembers,
+                    GenerateDelegates = true
+                });
+                fixture.Customize(new MutagenBaseCustomization());
+                fixture.Customize(new MutagenReleaseCustomization(Release));
+                fixture.Customize(new DefaultCustomization(UseMockFileSystem));
+                return fixture;
+            })
+        {
+        }
+    }
+}

--- a/Mutagen.Bethesda.Analyzers.Testing/Mutagen.Bethesda.Analyzers.Testing.csproj
+++ b/Mutagen.Bethesda.Analyzers.Testing/Mutagen.Bethesda.Analyzers.Testing.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net5.0</TargetFramework>
+        <TargetPlatformIdentifier>Windows</TargetPlatformIdentifier>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <PackageReference Include="AutoFixture.AutoMoq" Version="4.17.0" />
+      <PackageReference Include="Mutagen.Bethesda.Testing" Version="0.31.0" />
+    </ItemGroup>
+
+</Project>

--- a/Mutagen.Bethesda.Analyzers.sln
+++ b/Mutagen.Bethesda.Analyzers.sln
@@ -22,6 +22,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Mutagen.Bethesda.SkyrimAnal
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Mutagen.Bethesda.SkyrimAnalyzer.Tests", "Mutagen.Bethesda.SkyrimAnalyzer.Tests\Mutagen.Bethesda.SkyrimAnalyzer.Tests.csproj", "{D064B420-8DEC-4CDA-BC11-B9BFDC8C5EF8}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Mutagen.Bethesda.Analyzers.Testing", "Mutagen.Bethesda.Analyzers.Testing\Mutagen.Bethesda.Analyzers.Testing.csproj", "{BC0A7772-46BE-4155-9647-591D13AE5D2E}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -44,11 +46,16 @@ Global
 		{D064B420-8DEC-4CDA-BC11-B9BFDC8C5EF8}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D064B420-8DEC-4CDA-BC11-B9BFDC8C5EF8}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D064B420-8DEC-4CDA-BC11-B9BFDC8C5EF8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BC0A7772-46BE-4155-9647-591D13AE5D2E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BC0A7772-46BE-4155-9647-591D13AE5D2E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BC0A7772-46BE-4155-9647-591D13AE5D2E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BC0A7772-46BE-4155-9647-591D13AE5D2E}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{099DF49C-B15B-407C-93B3-4C63FBB50ACB} = {57D0B11F-05A3-44F3-9E34-FA371A806C6A}
 		{E824FD0B-EE06-4A42-96FC-AD13484160E2} = {57D0B11F-05A3-44F3-9E34-FA371A806C6A}
 		{49F13245-2CE4-41D0-9E82-CE9A917CEE80} = {65ADC99E-9E67-43B5-AEF5-A8975A1E6FFA}
 		{D064B420-8DEC-4CDA-BC11-B9BFDC8C5EF8} = {5F4F559E-143A-45A5-8EBB-CE759A7D67EC}
+		{BC0A7772-46BE-4155-9647-591D13AE5D2E} = {5F4F559E-143A-45A5-8EBB-CE759A7D67EC}
 	EndGlobalSection
 EndGlobal

--- a/Mutagen.Bethesda.SkyrimAnalyzer.Tests/MissingAssetsAnalyzerTests.cs
+++ b/Mutagen.Bethesda.SkyrimAnalyzer.Tests/MissingAssetsAnalyzerTests.cs
@@ -1,10 +1,13 @@
 ﻿using System.Collections.Generic;
 using System.IO;
 using System.IO.Abstractions.TestingHelpers;
+using FluentAssertions;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
+using Mutagen.Bethesda.Analyzers.Testing.AutoFixture;
 using Mutagen.Bethesda.Plugins.Records;
 using Mutagen.Bethesda.Skyrim;
+using Noggog;
 using Xunit;
 
 namespace Mutagen.Bethesda.SkyrimAnalyzer.Tests
@@ -65,6 +68,41 @@ namespace Mutagen.Bethesda.SkyrimAnalyzer.Tests
                 x => Assert.Equal(MissingAssetsAnalyzer.MissingTextureInTextureSet, x.ErrorDefinition),
                 x => Assert.Equal(MissingAssetsAnalyzer.MissingTextureInTextureSet, x.ErrorDefinition),
                 x => Assert.Equal(MissingAssetsAnalyzer.MissingTextureInTextureSet, x.ErrorDefinition));
+        }
+
+        [Theory, MoqData]
+        public void TestExistingTextureSetTextures(
+            Mock<ITextureSetGetter> textureSet,
+            FilePath existingDiffuse,
+            FilePath existingNormal,
+            FilePath existingSubsurfaceTint,
+            FilePath existingGlow,
+            FilePath existingHeight,
+            FilePath existingEnvironment,
+            FilePath existingMultilayer,
+            FilePath existingSpecular,
+            MissingAssetsAnalyzer analyzer)
+        {
+            textureSet.Setup(x => x.Diffuse)
+                .Returns(existingDiffuse);
+            textureSet.Setup(x => x.NormalOrGloss)
+                .Returns(existingNormal);
+            textureSet.Setup(x => x.EnvironmentMaskOrSubsurfaceTint)
+                .Returns(existingSubsurfaceTint);
+            textureSet.Setup(x => x.GlowOrDetailMap)
+                .Returns(existingGlow);
+            textureSet.Setup(x => x.Height)
+                .Returns(existingHeight);
+            textureSet.Setup(x => x.Environment)
+                .Returns(existingEnvironment);
+            textureSet.Setup(x => x.Multilayer)
+                .Returns(existingMultilayer);
+            textureSet.Setup(x => x.BacklightMaskOrSpecular)
+                .Returns(existingSpecular);
+
+            var result = analyzer.AnalyzeRecord(textureSet.Object);
+
+            result.Errors.Should().BeEmpty();
         }
 
         private static ArmorModel CreateArmorModel()

--- a/Mutagen.Bethesda.SkyrimAnalyzer.Tests/Mutagen.Bethesda.SkyrimAnalyzer.Tests.csproj
+++ b/Mutagen.Bethesda.SkyrimAnalyzer.Tests/Mutagen.Bethesda.SkyrimAnalyzer.Tests.csproj
@@ -2,10 +2,12 @@
 
     <PropertyGroup>
         <IsPackable>false</IsPackable>
+        <TargetPlatformIdentifier>Windows</TargetPlatformIdentifier>
     </PropertyGroup>
 
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+        <PackageReference Include="Mutagen.Bethesda.Testing" Version="0.31.0" />
         <PackageReference Include="xunit" Version="2.4.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -19,6 +21,7 @@
 
     <ItemGroup>
       <ProjectReference Include="..\Mutagen.Bethesda.Analyzers.TestingUtils\Mutagen.Bethesda.Analyzers.TestingUtils.csproj" />
+      <ProjectReference Include="..\Mutagen.Bethesda.Analyzers.Testing\Mutagen.Bethesda.Analyzers.Testing.csproj" />
       <ProjectReference Include="..\Mutagen.Bethesda.SkyrimAnalyzer\Mutagen.Bethesda.SkyrimAnalyzer.csproj" />
     </ItemGroup>
 


### PR DESCRIPTION
Added `MoqData` which is an Autofixture attribute that uses `Mutagen.Bethesda.Testing`, but with a Moq backing instead

Added a test for `MissingAssetsAnalyzerTests`, just to give a little proof of concept.  

Few things I like about it
## Easier `MissingAssetsAnalyzer` sut instantiation. 
Didn't need to even interact with ILogger or MockFileSystem.  Didn't care to access/use them, so they're hidden away.

Side note:
In the situations where we did care about dependency X of a SUT we were testing, we can still opt in to get access to just that one:
```cs
public void SomeOtherTest(
    [Frozen] Mock<ISomeDependencyOurAnalyzerHas> dep
    MissingAssetsAnalyzer analyzer)
{
    dep.Setup(x => x.SomeMember).Returns(45);
    // ...            
```
If `MissingAssetsAnalyzer` had 6 dependencies, we still dont have to deal with most of them, while getting access to the one we want to mock it as we like.  `[Frozen]` ensures the mock is a singleton so the one we're getting is also the one passed to the sut

## Easy existing file test
Since the MoqData attribute is making our `MockFileSystem` and injecting it into our analyzer for us, we can just define `FilePath existingDiffuse` and it will make a file that exists within the file system for us.

This made for a very easy `TestExistingTextureSetTextures` where I didn't have to spam the page doing all the `fileSystem.File.CreateFile(somePath)` prep.  Just used the paths in the TextureSet mock and then good to go

## General Thoughts
I dont think it needs to be used by everyone contributing if they prefer without, but I'd like to have it on the toolbelt for when I'm writing tests myself.