### PR TITLE
Make data directory config source optional

### DIFF
--- a/Mutagen.Bethesda.Analyzers.Engine/Config/ConfigDirectoryProvider.cs
+++ b/Mutagen.Bethesda.Analyzers.Engine/Config/ConfigDirectoryProvider.cs
@@ -21,10 +21,13 @@ public class ConfigDirectoryProvider(
             }
             catch (Exception)
             {
-                yield break;
+                dataDirectory = null;
             }
 
-            yield return dataDirectory.Value;
+            if (dataDirectory.HasValue)
+            {
+                yield return dataDirectory.Value;
+            }
         }
     }
 }

--- a/Mutagen.Bethesda.Analyzers.Engine/Config/ConfigDirectoryProvider.cs
+++ b/Mutagen.Bethesda.Analyzers.Engine/Config/ConfigDirectoryProvider.cs
@@ -13,7 +13,18 @@ public class ConfigDirectoryProvider(
         get
         {
             yield return currentDirectoryProvider.CurrentDirectory;
-            yield return dataDirectoryProvider.Path;
+
+            DirectoryPath? dataDirectory;
+            try
+            {
+                dataDirectory = dataDirectoryProvider.Path;
+            }
+            catch (Exception)
+            {
+                yield break;
+            }
+
+            yield return dataDirectory.Value;
         }
     }
 }


### PR DESCRIPTION
Useful in case the data directory doesn't exist like in a CI environment. A custom path for a data directory can still be passed via config entry. It's just a workaround so potentially we might want to create a better solution for this problem.