### PR TITLE
Blacklisted mods provider

### DIFF
--- a/Mutagen.Bethesda.Analyzers.Cli/Args/RunAnalyzersCommand.cs
+++ b/Mutagen.Bethesda.Analyzers.Cli/Args/RunAnalyzersCommand.cs
@@ -28,6 +28,9 @@ public class RunAnalyzersCommand : IMinimumSeverityConfiguration
     [Option("LoadOrder", HelpText = "Optional list of mod file names to set a custom load order, separated by commas")]
     public string? LoadOrder { get; set; } = null;
 
+    [Option("BlacklistedMods", HelpText = "Optional list of mod file names excluded from analyzing, separated by commas")]
+    public string? BlacklistedMods { get; set; } = null;
+
     [Option('t', "NumThreads", HelpText = "Number of threads to use")]
     public int? NumThreads { get; set; }
 

--- a/Mutagen.Bethesda.Analyzers.Cli/Modules/AnalyzerCommandModule.cs
+++ b/Mutagen.Bethesda.Analyzers.Cli/Modules/AnalyzerCommandModule.cs
@@ -8,6 +8,7 @@ using Mutagen.Bethesda.Analyzers.Cli.Args;
 using Mutagen.Bethesda.Analyzers.Cli.Overrides;
 using Mutagen.Bethesda.Analyzers.Config;
 using Mutagen.Bethesda.Analyzers.Config.Run;
+using Mutagen.Bethesda.Analyzers.Drivers;
 using Mutagen.Bethesda.Analyzers.Reporting.Handlers;
 using Mutagen.Bethesda.Environments.DI;
 using Mutagen.Bethesda.Plugins;
@@ -71,6 +72,19 @@ public class AnalyzerCommandModule(RunAnalyzersCommand command) : Module
             builder.RegisterInstance(new InjectedEnabledPluginListingsProvider(loadOrder)).As<IEnabledPluginListingsProvider>();
             builder.RegisterType<NullPluginListingsPathProvider>().As<IPluginListingsPathProvider>();
             builder.RegisterType<NullCreationClubListingsPathProvider>().As<ICreationClubListingsPathProvider>();
+        }
+
+        if (command.BlacklistedMods is not null)
+        {
+            var blacklistedMods = command.BlacklistedMods?.Split(',')
+                .Select(x => x.Trim())
+                .Select(x => ModKey.FromFileName(x)) ?? [];
+
+            builder.RegisterInstance(new InjectedBlacklistedModsProvider(blacklistedMods)).As<IBlacklistedModsProvider>();
+        }
+        else
+        {
+            builder.RegisterInstance(new InjectedBlacklistedModsProvider([])).As<IBlacklistedModsProvider>();
         }
     }
 }

--- a/Mutagen.Bethesda.Analyzers.Cli/Modules/AnalyzerCommandModule.cs
+++ b/Mutagen.Bethesda.Analyzers.Cli/Modules/AnalyzerCommandModule.cs
@@ -81,9 +81,5 @@ public class AnalyzerCommandModule(RunAnalyzersCommand command) : Module
 
             builder.RegisterInstance(new InjectedBlacklistedModsProvider(blacklistedMods)).As<IBlacklistedModsProvider>();
         }
-        else
-        {
-            builder.RegisterInstance(new InjectedBlacklistedModsProvider([])).As<IBlacklistedModsProvider>();
-        }
     }
 }

--- a/Mutagen.Bethesda.Analyzers.Cli/Modules/AnalyzerCommandModule.cs
+++ b/Mutagen.Bethesda.Analyzers.Cli/Modules/AnalyzerCommandModule.cs
@@ -8,7 +8,6 @@ using Mutagen.Bethesda.Analyzers.Cli.Args;
 using Mutagen.Bethesda.Analyzers.Cli.Overrides;
 using Mutagen.Bethesda.Analyzers.Config;
 using Mutagen.Bethesda.Analyzers.Config.Run;
-using Mutagen.Bethesda.Analyzers.Drivers;
 using Mutagen.Bethesda.Analyzers.Reporting.Handlers;
 using Mutagen.Bethesda.Environments.DI;
 using Mutagen.Bethesda.Plugins;

--- a/Mutagen.Bethesda.Analyzers.Cli/Modules/RunAnalyzerModule.cs
+++ b/Mutagen.Bethesda.Analyzers.Cli/Modules/RunAnalyzerModule.cs
@@ -16,6 +16,7 @@ public class RunAnalyzerModule : Module
         builder.RegisterDecorator<MinimumSeverityFilter, IReportDropbox>();
         builder.RegisterDecorator<SeverityAdjuster, IReportDropbox>();
         builder.RegisterDecorator<DisallowedParametersChecker, IReportDropbox>();
+        builder.RegisterDecorator<FilterBlacklistedReports, IReportDropbox>();
 
         builder.RegisterType<ConsoleReportHandler>().AsImplementedInterfaces();
 

--- a/Mutagen.Bethesda.Analyzers.Cli/Modules/RunConfigModule.cs
+++ b/Mutagen.Bethesda.Analyzers.Cli/Modules/RunConfigModule.cs
@@ -35,5 +35,7 @@ public class RunConfigModule(IRunConfigLookup runConfig) : Module
             builder.RegisterType<CsvReportHandler>().AsImplementedInterfaces().SingleInstance();
             builder.RegisterInstance(new CsvInputs(runConfig.OutputFilePath)).AsSelf().AsImplementedInterfaces();
         }
+
+        builder.RegisterInstance(new InjectedBlacklistedModsProvider(runConfig.BlacklistMods ?? [])).As<IBlacklistedModsProvider>();
     }
 }

--- a/Mutagen.Bethesda.Analyzers.Cli/Modules/RunConfigModule.cs
+++ b/Mutagen.Bethesda.Analyzers.Cli/Modules/RunConfigModule.cs
@@ -29,5 +29,11 @@ public class RunConfigModule(IRunConfigLookup runConfig) : Module
             builder.RegisterType<CsvReportHandler>().AsImplementedInterfaces().SingleInstance();
             builder.RegisterInstance(new CsvInputs(runConfig.OutputFilePath)).AsSelf().AsImplementedInterfaces();
         }
+
+        if (runConfig.OutputFilePath is not null)
+        {
+            builder.RegisterType<CsvReportHandler>().AsImplementedInterfaces().SingleInstance();
+            builder.RegisterInstance(new CsvInputs(runConfig.OutputFilePath)).AsSelf().AsImplementedInterfaces();
+        }
     }
 }

--- a/Mutagen.Bethesda.Analyzers.Cli/Overrides/NullCreationClubListingsPathProvider.cs
+++ b/Mutagen.Bethesda.Analyzers.Cli/Overrides/NullCreationClubListingsPathProvider.cs
@@ -1,5 +1,6 @@
 ﻿using Mutagen.Bethesda.Plugins.Order.DI;
 using Noggog;
+
 namespace Mutagen.Bethesda.Analyzers.Cli.Overrides;
 
 internal class NullCreationClubListingsPathProvider : ICreationClubListingsPathProvider

--- a/Mutagen.Bethesda.Analyzers.Cli/Overrides/NullPluginListingsPathProvider.cs
+++ b/Mutagen.Bethesda.Analyzers.Cli/Overrides/NullPluginListingsPathProvider.cs
@@ -1,5 +1,6 @@
 ﻿using Mutagen.Bethesda.Plugins.Order.DI;
 using Noggog;
+
 namespace Mutagen.Bethesda.Analyzers.Cli.Overrides;
 
 internal class NullPluginListingsPathProvider : IPluginListingsPathProvider

--- a/Mutagen.Bethesda.Analyzers.Engine/Config/Run/IBlacklistedModsProvider.cs
+++ b/Mutagen.Bethesda.Analyzers.Engine/Config/Run/IBlacklistedModsProvider.cs
@@ -1,0 +1,16 @@
+﻿using Mutagen.Bethesda.Plugins;
+
+namespace Mutagen.Bethesda.Analyzers.Config.Run;
+
+/// <summary>
+/// Provides a mechanism to disallow certain mods from being analyzed.
+/// </summary>
+public interface IBlacklistedModsProvider
+{
+    /// <summary>
+    /// Returns true if the mod is blacklisted and should not be analyzed.
+    /// </summary>
+    /// <param name="modKey">Mod to check</param>
+    /// <returns>True if the mod is blacklisted</returns>
+    public bool IsBlacklisted(ModKey modKey);
+}

--- a/Mutagen.Bethesda.Analyzers.Engine/Config/Run/InjectedBlacklistedModsProvider.cs
+++ b/Mutagen.Bethesda.Analyzers.Engine/Config/Run/InjectedBlacklistedModsProvider.cs
@@ -1,0 +1,13 @@
+using Mutagen.Bethesda.Plugins;
+
+namespace Mutagen.Bethesda.Analyzers.Config.Run;
+
+public class InjectedBlacklistedModsProvider(IEnumerable<ModKey> blacklistedMods) : IBlacklistedModsProvider
+{
+    private readonly List<ModKey> _blacklistedMods = blacklistedMods.ToList();
+
+    public bool IsBlacklisted(ModKey modKey)
+    {
+        return _blacklistedMods.Contains(modKey);
+    }
+}

--- a/Mutagen.Bethesda.Analyzers.Engine/Config/Run/ProcessBlacklistedMods.cs
+++ b/Mutagen.Bethesda.Analyzers.Engine/Config/Run/ProcessBlacklistedMods.cs
@@ -1,0 +1,30 @@
+﻿using Microsoft.Extensions.Logging;
+using Mutagen.Bethesda.Plugins;
+
+namespace Mutagen.Bethesda.Analyzers.Config.Run;
+
+public class ProcessBlacklistedMods(ILogger<ProcessBlacklistedMods> logger) : IConfigReaderProcessor<IRunConfig>
+{
+    public bool Process(IRunConfig config, IReadOnlyList<string> instructionParts, string value)
+    {
+        // environment.blacklisted_mods = <mod1>,<mod2>,...
+        if (instructionParts.Count != 3) return false;
+
+        if (instructionParts[0] is not "environment") return false;
+        if (instructionParts[1] is not "blacklisted_mods") return false;
+
+        var mods = value.Split(',');
+        try
+        {
+            var modKeys = mods.Select(fileName => ModKey.FromFileName(fileName.Trim())).ToList();
+            config.OverrideLoadOrderSetToMods(modKeys);
+        }
+        catch (ArgumentException e)
+        {
+            logger.LogError(e, "Error parsing ModKeys");
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/Mutagen.Bethesda.Analyzers.Engine/Config/Run/ProcessBlacklistedMods.cs
+++ b/Mutagen.Bethesda.Analyzers.Engine/Config/Run/ProcessBlacklistedMods.cs
@@ -8,7 +8,7 @@ public class ProcessBlacklistedMods(ILogger<ProcessBlacklistedMods> logger) : IC
     public bool Process(IRunConfig config, IReadOnlyList<string> instructionParts, string value)
     {
         // environment.blacklisted_mods = <mod1>,<mod2>,...
-        if (instructionParts.Count != 3) return false;
+        if (instructionParts.Count != 2) return false;
 
         if (instructionParts[0] is not "environment") return false;
         if (instructionParts[1] is not "blacklisted_mods") return false;

--- a/Mutagen.Bethesda.Analyzers.Engine/Config/Run/ProcessBlacklistedMods.cs
+++ b/Mutagen.Bethesda.Analyzers.Engine/Config/Run/ProcessBlacklistedMods.cs
@@ -17,7 +17,7 @@ public class ProcessBlacklistedMods(ILogger<ProcessBlacklistedMods> logger) : IC
         try
         {
             var modKeys = mods.Select(fileName => ModKey.FromFileName(fileName.Trim())).ToList();
-            config.OverrideLoadOrderSetToMods(modKeys);
+            config.OverrideBlacklistMods(modKeys);
         }
         catch (ArgumentException e)
         {

--- a/Mutagen.Bethesda.Analyzers.Engine/Config/Run/RunConfig.cs
+++ b/Mutagen.Bethesda.Analyzers.Engine/Config/Run/RunConfig.cs
@@ -6,8 +6,9 @@ namespace Mutagen.Bethesda.Analyzers.Config.Run;
 public interface IRunConfigLookup
 {
     DirectoryPath? DataDirectoryPath { get; }
-    IEnumerable<ModKey>? LoadOrderSetToMods { get; }
     FilePath? OutputFilePath { get; }
+    IEnumerable<ModKey>? LoadOrderSetToMods { get; }
+    IEnumerable<ModKey>? BlacklistMods { get; }
     bool PrintMetadata { get; set; }
 }
 
@@ -16,6 +17,7 @@ public interface IRunConfig : IRunConfigLookup
     void OverrideDataDirectory(DirectoryPath path);
     void OverrideOutputFilePath(FilePath filePath);
     void OverrideLoadOrderSetToMods(IEnumerable<ModKey> mods);
+    void OverrideBlacklistMods(IEnumerable<ModKey> mods);
     void OverridePrintMetadata(bool printMetadata);
 }
 
@@ -23,11 +25,13 @@ public class RunConfig : IRunConfig
 {
     public DirectoryPath? DataDirectoryPath { get; private set; }
     public FilePath? OutputFilePath { get; private set; }
-    public bool PrintMetadata { get; set; }
     public IEnumerable<ModKey>? LoadOrderSetToMods { get; private set; }
+    public IEnumerable<ModKey>? BlacklistMods { get; private set; }
+    public bool PrintMetadata { get; set; }
 
     public void OverrideDataDirectory(DirectoryPath path) => DataDirectoryPath = path;
     public void OverrideOutputFilePath(FilePath filePath) => OutputFilePath = filePath;
     public void OverrideLoadOrderSetToMods(IEnumerable<ModKey> mods) => LoadOrderSetToMods = mods;
+    public void OverrideBlacklistMods(IEnumerable<ModKey> mods) => BlacklistMods = mods;
     public void OverridePrintMetadata(bool printMetadata) => PrintMetadata = printMetadata;
 }

--- a/Mutagen.Bethesda.Analyzers.Engine/Drivers/RecordFrame/RecordFrameDriver.cs
+++ b/Mutagen.Bethesda.Analyzers.Engine/Drivers/RecordFrame/RecordFrameDriver.cs
@@ -1,6 +1,5 @@
 using System.Buffers;
 using Mutagen.Bethesda.Analyzers.Config.Run;
-using Mutagen.Bethesda.Analyzers.SDK;
 using Mutagen.Bethesda.Analyzers.SDK.Analyzers;
 using Mutagen.Bethesda.Environments.DI;
 using Mutagen.Bethesda.Plugins;

--- a/Mutagen.Bethesda.Analyzers.Engine/Drivers/RecordFrame/RecordFrameDriver.cs
+++ b/Mutagen.Bethesda.Analyzers.Engine/Drivers/RecordFrame/RecordFrameDriver.cs
@@ -1,4 +1,6 @@
 using System.Buffers;
+using Mutagen.Bethesda.Analyzers.Config.Run;
+using Mutagen.Bethesda.Analyzers.SDK;
 using Mutagen.Bethesda.Analyzers.SDK.Analyzers;
 using Mutagen.Bethesda.Environments.DI;
 using Mutagen.Bethesda.Plugins;
@@ -18,6 +20,7 @@ public class RecordFrameDriver : IIsolatedDriver, IContextualDriver
     private readonly GameConstants _constants;
     private readonly IGameReleaseContext _gameReleaseContext;
     private readonly IDataDirectoryProvider _dataDataDirectoryProvider;
+    private readonly IBlacklistedModsProvider _blacklistedModsProvider;
 
     private class Drivers
     {
@@ -39,10 +42,12 @@ public class RecordFrameDriver : IIsolatedDriver, IContextualDriver
         IDataDirectoryProvider dataDataDirectoryProvider,
         IIsolatedRecordFrameAnalyzerDriver[] isolatedDrivers,
         IContextualRecordFrameAnalyzerDriver[] contextualDrivers,
+        IBlacklistedModsProvider blacklistedModsProvider,
         IWorkDropoff dropoff)
     {
         _gameReleaseContext = gameReleaseContext;
         _dataDataDirectoryProvider = dataDataDirectoryProvider;
+        _blacklistedModsProvider = blacklistedModsProvider;
         _dropoff = dropoff;
         _constants = GameConstants.Get(_gameReleaseContext.Release);
         foreach (var drivers in isolatedDrivers
@@ -68,6 +73,8 @@ public class RecordFrameDriver : IIsolatedDriver, IContextualDriver
             .Select(async mod =>
             {
                 if (driverParams.CancellationToken.IsCancellationRequested) return;
+                if (_blacklistedModsProvider.IsBlacklisted(mod.ModKey)) return;
+
                 var modPath = Path.Combine(_dataDataDirectoryProvider.Path, mod.ModKey.FileName);
 
                 var parsingMeta = ParsingMeta.Factory(new BinaryReadParameters(), _gameReleaseContext.Release, modPath);

--- a/Mutagen.Bethesda.Analyzers.Engine/Drivers/Records/ByGenericTypeRecordContextualDriver.cs
+++ b/Mutagen.Bethesda.Analyzers.Engine/Drivers/Records/ByGenericTypeRecordContextualDriver.cs
@@ -1,4 +1,6 @@
-﻿using Mutagen.Bethesda.Analyzers.SDK.Analyzers;
+﻿using Mutagen.Bethesda.Analyzers.Config.Run;
+using Mutagen.Bethesda.Analyzers.SDK;
+using Mutagen.Bethesda.Analyzers.SDK.Analyzers;
 using Mutagen.Bethesda.Plugins.Records;
 using Noggog.WorkEngine;
 
@@ -9,6 +11,7 @@ public class ByGenericTypeRecordContextualDriver<TMajor> : IContextualDriver
 {
     private readonly IWorkDropoff _dropoff;
     private readonly IContextualRecordAnalyzer<TMajor>[] _contextualRecordAnalyzers;
+    private readonly IBlacklistedModsProvider _blacklistedModsProvider;
 
     public bool Applicable => _contextualRecordAnalyzers.Length > 0;
 
@@ -16,9 +19,11 @@ public class ByGenericTypeRecordContextualDriver<TMajor> : IContextualDriver
 
     public ByGenericTypeRecordContextualDriver(
         IAnalyzerProvider<IContextualRecordAnalyzer<TMajor>> contextualRecordAnalyzerProvider,
+        IBlacklistedModsProvider blacklistedModsProvider,
         IWorkDropoff dropoff)
     {
         _contextualRecordAnalyzers = contextualRecordAnalyzerProvider.GetAnalyzers().ToArray();
+        _blacklistedModsProvider = blacklistedModsProvider;
         _dropoff = dropoff;
     }
 
@@ -30,6 +35,7 @@ public class ByGenericTypeRecordContextualDriver<TMajor> : IContextualDriver
         {
             if (driverParams.CancellationToken.IsCancellationRequested) return;
             if (listing.Mod is null) continue;
+            if (_blacklistedModsProvider.IsBlacklisted(listing.ModKey)) continue;
 
             await Task.WhenAll(listing.Mod.EnumerateMajorRecords<TMajor>().SelectMany(rec =>
             {

--- a/Mutagen.Bethesda.Analyzers.Engine/Drivers/Records/ByGenericTypeRecordContextualDriver.cs
+++ b/Mutagen.Bethesda.Analyzers.Engine/Drivers/Records/ByGenericTypeRecordContextualDriver.cs
@@ -1,5 +1,4 @@
 ﻿using Mutagen.Bethesda.Analyzers.Config.Run;
-using Mutagen.Bethesda.Analyzers.SDK;
 using Mutagen.Bethesda.Analyzers.SDK.Analyzers;
 using Mutagen.Bethesda.Plugins.Records;
 using Noggog.WorkEngine;

--- a/Mutagen.Bethesda.Analyzers.Engine/Engines/ContextualEngine.cs
+++ b/Mutagen.Bethesda.Analyzers.Engine/Engines/ContextualEngine.cs
@@ -1,4 +1,6 @@
-﻿using Mutagen.Bethesda.Analyzers.Drivers;
+﻿using Mutagen.Bethesda.Analyzers.Config.Run;
+using Mutagen.Bethesda.Analyzers.Drivers;
+using Mutagen.Bethesda.Analyzers.SDK;
 using Mutagen.Bethesda.Analyzers.SDK.Drops;
 using Mutagen.Bethesda.Environments.DI;
 using Noggog.WorkEngine;
@@ -12,6 +14,7 @@ public interface IContextualEngine : IEngine
 
 public class ContextualEngine : IContextualEngine
 {
+    private readonly IBlacklistedModsProvider _blacklistedModsProvider;
     private readonly IWorkDropoff _workDropoff;
     public IReportDropbox ReportDropbox { get; }
     public IGameEnvironmentProvider EnvGetter { get; }
@@ -26,8 +29,10 @@ public class ContextualEngine : IContextualEngine
         IDriverProvider<IContextualDriver> contextualDrivers,
         IDriverProvider<IIsolatedDriver> isolatedDrivers,
         IReportDropbox reportDropbox,
+        IBlacklistedModsProvider blacklistedModsProvider,
         IWorkDropoff workDropoff)
     {
+        _blacklistedModsProvider = blacklistedModsProvider;
         _workDropoff = workDropoff;
         ReportDropbox = reportDropbox;
         EnvGetter = envGetter;
@@ -47,8 +52,10 @@ public class ContextualEngine : IContextualEngine
         {
             foreach (var listing in env.LoadOrder.ListedOrder)
             {
-                if (listing.Mod is null) continue;
                 if (cancel.IsCancellationRequested) return;
+
+                if (listing.Mod is null) continue;
+                if (_blacklistedModsProvider.IsBlacklisted(listing.ModKey)) continue;
 
                 var modPath = Path.Combine(env.DataFolderPath.Path, listing.ModKey.FileName);
 

--- a/Mutagen.Bethesda.Analyzers.Engine/Engines/ContextualEngine.cs
+++ b/Mutagen.Bethesda.Analyzers.Engine/Engines/ContextualEngine.cs
@@ -1,6 +1,5 @@
 ﻿using Mutagen.Bethesda.Analyzers.Config.Run;
 using Mutagen.Bethesda.Analyzers.Drivers;
-using Mutagen.Bethesda.Analyzers.SDK;
 using Mutagen.Bethesda.Analyzers.SDK.Drops;
 using Mutagen.Bethesda.Environments.DI;
 using Noggog.WorkEngine;

--- a/Mutagen.Bethesda.Analyzers.Engine/Engines/IsolatedEngine.cs
+++ b/Mutagen.Bethesda.Analyzers.Engine/Engines/IsolatedEngine.cs
@@ -1,4 +1,6 @@
-﻿using Mutagen.Bethesda.Analyzers.Drivers;
+﻿using Mutagen.Bethesda.Analyzers.Config.Run;
+using Mutagen.Bethesda.Analyzers.Drivers;
+using Mutagen.Bethesda.Analyzers.SDK;
 using Mutagen.Bethesda.Analyzers.SDK.Drops;
 using Mutagen.Bethesda.Plugins;
 using Mutagen.Bethesda.Plugins.Records.DI;
@@ -13,6 +15,7 @@ public interface IIsolatedEngine : IEngine
 
 public class IsolatedEngine : IIsolatedEngine
 {
+    private readonly IBlacklistedModsProvider _blacklistedModsProvider;
     private readonly IWorkDropoff _workDropoff;
     public IModImporter ModImporter { get; }
     public IDriverProvider<IIsolatedDriver> IsolatedDrivers { get; }
@@ -22,10 +25,12 @@ public class IsolatedEngine : IIsolatedEngine
     public IsolatedEngine(
         IModImporter modImporter,
         IDriverProvider<IIsolatedDriver> isolatedDrivers,
+        IBlacklistedModsProvider blacklistedModsProvider,
         IWorkDropoff workDropoff)
     {
         ModImporter = modImporter;
         IsolatedDrivers = isolatedDrivers;
+        _blacklistedModsProvider = blacklistedModsProvider;
         _workDropoff = workDropoff;
     }
 
@@ -35,6 +40,8 @@ public class IsolatedEngine : IIsolatedEngine
         CancellationToken cancel)
     {
         if (cancel.IsCancellationRequested) return;
+        if (_blacklistedModsProvider.IsBlacklisted(modPath.ModKey)) return;
+
         var mod = ModImporter.Import(modPath);
 
         var driverParams = new IsolatedDriverParams(

--- a/Mutagen.Bethesda.Analyzers.Engine/Engines/IsolatedEngine.cs
+++ b/Mutagen.Bethesda.Analyzers.Engine/Engines/IsolatedEngine.cs
@@ -1,6 +1,5 @@
 ﻿using Mutagen.Bethesda.Analyzers.Config.Run;
 using Mutagen.Bethesda.Analyzers.Drivers;
-using Mutagen.Bethesda.Analyzers.SDK;
 using Mutagen.Bethesda.Analyzers.SDK.Drops;
 using Mutagen.Bethesda.Plugins;
 using Mutagen.Bethesda.Plugins.Records.DI;

--- a/Mutagen.Bethesda.Analyzers.Engine/Reporting/Drops/FilterBlacklistedReports.cs
+++ b/Mutagen.Bethesda.Analyzers.Engine/Reporting/Drops/FilterBlacklistedReports.cs
@@ -1,0 +1,26 @@
+﻿using Mutagen.Bethesda.Analyzers.Config.Run;
+using Mutagen.Bethesda.Analyzers.Drivers;
+using Mutagen.Bethesda.Analyzers.SDK.Drops;
+using Mutagen.Bethesda.Analyzers.SDK.Topics;
+using Mutagen.Bethesda.Plugins;
+using Mutagen.Bethesda.Plugins.Records;
+
+namespace Mutagen.Bethesda.Analyzers.Reporting.Drops;
+
+public class FilterBlacklistedReports(IReportDropbox dropbox, IBlacklistedModsProvider blacklistedModsProvider) : IReportDropbox
+{
+    public void Dropoff(ReportContextParameters parameters, ModKey mod, IMajorRecordIdentifierGetter record, Topic topic)
+    {
+        if (blacklistedModsProvider.IsBlacklisted(mod))
+        {
+            return;
+        }
+
+        dropbox.Dropoff(parameters, mod, record, topic);
+    }
+
+    public void Dropoff(ReportContextParameters parameters, Topic topic)
+    {
+        dropbox.Dropoff(parameters, topic);
+    }
+}

--- a/Mutagen.Bethesda.Analyzers.Engine/Reporting/Drops/FilterBlacklistedReports.cs
+++ b/Mutagen.Bethesda.Analyzers.Engine/Reporting/Drops/FilterBlacklistedReports.cs
@@ -1,5 +1,4 @@
 ﻿using Mutagen.Bethesda.Analyzers.Config.Run;
-using Mutagen.Bethesda.Analyzers.Drivers;
 using Mutagen.Bethesda.Analyzers.SDK.Drops;
 using Mutagen.Bethesda.Analyzers.SDK.Topics;
 using Mutagen.Bethesda.Plugins;

--- a/Mutagen.Bethesda.Analyzers.Skyrim/Extensions/ActorValueExtensions.cs
+++ b/Mutagen.Bethesda.Analyzers.Skyrim/Extensions/ActorValueExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using Mutagen.Bethesda.Skyrim;
+
 namespace Mutagen.Bethesda.Analyzers.Skyrim.Extensions;
 
 public static class ActorValueExtensions

--- a/Mutagen.Bethesda.Analyzers.Skyrim/Extensions/ArmorExtensions.cs
+++ b/Mutagen.Bethesda.Analyzers.Skyrim/Extensions/ArmorExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using Mutagen.Bethesda.Skyrim;
+
 namespace Mutagen.Bethesda.Analyzers.Skyrim.Extensions;
 
 public static class ArmorExtensions

--- a/Mutagen.Bethesda.Analyzers.Skyrim/Extensions/CellExtensions.cs
+++ b/Mutagen.Bethesda.Analyzers.Skyrim/Extensions/CellExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using Mutagen.Bethesda.Plugins.Cache;
 using Mutagen.Bethesda.Skyrim;
+
 namespace Mutagen.Bethesda.Analyzers.Skyrim.Extensions;
 
 public static class CellExtensions

--- a/Mutagen.Bethesda.Analyzers.Skyrim/Extensions/ConditionDataExtensions.cs
+++ b/Mutagen.Bethesda.Analyzers.Skyrim/Extensions/ConditionDataExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using Mutagen.Bethesda.Skyrim;
+
 namespace Mutagen.Bethesda.Analyzers.Skyrim.Extensions;
 
 public static class ConditionDataExtensions

--- a/Mutagen.Bethesda.Analyzers.Skyrim/Extensions/FactionExtensions.cs
+++ b/Mutagen.Bethesda.Analyzers.Skyrim/Extensions/FactionExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using Mutagen.Bethesda.Skyrim;
+
 namespace Mutagen.Bethesda.Analyzers.Skyrim.Extensions;
 
 public static class FactionExtensions

--- a/Mutagen.Bethesda.Analyzers.Skyrim/Extensions/FurnitureExtensions.cs
+++ b/Mutagen.Bethesda.Analyzers.Skyrim/Extensions/FurnitureExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using Mutagen.Bethesda.Skyrim;
+
 namespace Mutagen.Bethesda.Analyzers.Skyrim.Extensions;
 
 public static class FurnitureExtensions

--- a/Mutagen.Bethesda.Analyzers.Skyrim/Extensions/IHaveVirtualMachineAdapterExtensions.cs
+++ b/Mutagen.Bethesda.Analyzers.Skyrim/Extensions/IHaveVirtualMachineAdapterExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using Mutagen.Bethesda.Skyrim;
+
 namespace Mutagen.Bethesda.Analyzers.Skyrim.Extensions;
 
 public static class IHaveVirtualMachineAdapterExtensions

--- a/Mutagen.Bethesda.Analyzers.Skyrim/Extensions/IHaveVirtualMachineAdapterExtensions.cs
+++ b/Mutagen.Bethesda.Analyzers.Skyrim/Extensions/IHaveVirtualMachineAdapterExtensions.cs
@@ -5,7 +5,7 @@ public static class IHaveVirtualMachineAdapterExtensions
 {
     public static IScriptEntryGetter? GetScript(this IHaveVirtualMachineAdapterGetter npc, string name)
     {
-        return npc.VirtualMachineAdapter?.Scripts.FirstOrDefault(script => script.Name == name);
+        return npc.VirtualMachineAdapter?.Scripts.FirstOrDefault(script => string.Equals(script.Name, name, StringComparison.OrdinalIgnoreCase));
     }
 
     public static bool HasScript(this IHaveVirtualMachineAdapterGetter npc, string name)

--- a/Mutagen.Bethesda.Analyzers.Skyrim/Extensions/LeveledItemExtensions.cs
+++ b/Mutagen.Bethesda.Analyzers.Skyrim/Extensions/LeveledItemExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using Mutagen.Bethesda.Plugins.Cache;
 using Mutagen.Bethesda.Plugins.Records;
 using Mutagen.Bethesda.Skyrim;
+
 namespace Mutagen.Bethesda.Analyzers.Skyrim.Extensions;
 
 public static class LeveledItemExtensions

--- a/Mutagen.Bethesda.Analyzers.Skyrim/Extensions/LocationExtensions.cs
+++ b/Mutagen.Bethesda.Analyzers.Skyrim/Extensions/LocationExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using Mutagen.Bethesda.Plugins;
 using Mutagen.Bethesda.Plugins.Cache;
 using Mutagen.Bethesda.Skyrim;
+
 namespace Mutagen.Bethesda.Analyzers.Skyrim.Extensions;
 
 public static class LocationExtensions

--- a/Mutagen.Bethesda.Analyzers.Skyrim/Extensions/NpcExtensions.cs
+++ b/Mutagen.Bethesda.Analyzers.Skyrim/Extensions/NpcExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using Mutagen.Bethesda.Plugins.Cache;
 using Mutagen.Bethesda.Skyrim;
+
 namespace Mutagen.Bethesda.Analyzers.Skyrim.Extensions;
 
 public static class NpcExtensions

--- a/Mutagen.Bethesda.Analyzers.Skyrim/Extensions/PlacedNpcExtensions.cs
+++ b/Mutagen.Bethesda.Analyzers.Skyrim/Extensions/PlacedNpcExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using Mutagen.Bethesda.Plugins;
 using Mutagen.Bethesda.Skyrim;
+
 namespace Mutagen.Bethesda.Analyzers.Skyrim.Extensions;
 
 public static class PlacedNpcExtensions

--- a/Mutagen.Bethesda.Analyzers.Skyrim/Extensions/PlacedObjectExtensions.cs
+++ b/Mutagen.Bethesda.Analyzers.Skyrim/Extensions/PlacedObjectExtensions.cs
@@ -2,6 +2,7 @@
 using Mutagen.Bethesda.Plugins;
 using Mutagen.Bethesda.Plugins.Cache;
 using Mutagen.Bethesda.Skyrim;
+
 namespace Mutagen.Bethesda.Analyzers.Skyrim.Extensions;
 
 public static class PlacedObjectExtensions

--- a/Mutagen.Bethesda.Analyzers.Skyrim/Extensions/RaceExtensions.cs
+++ b/Mutagen.Bethesda.Analyzers.Skyrim/Extensions/RaceExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using Mutagen.Bethesda.Skyrim;
+
 namespace Mutagen.Bethesda.Analyzers.Skyrim.Extensions;
 
 public static class RaceExtensions

--- a/Mutagen.Bethesda.Analyzers.Skyrim/Extensions/ScriptEntryExtensions.cs
+++ b/Mutagen.Bethesda.Analyzers.Skyrim/Extensions/ScriptEntryExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using Mutagen.Bethesda.Skyrim;
+
 namespace Mutagen.Bethesda.Analyzers.Skyrim.Extensions;
 
 public static class ScriptEntryExtensions

--- a/Mutagen.Bethesda.Analyzers.Skyrim/Extensions/WorldspaceExtensions.cs
+++ b/Mutagen.Bethesda.Analyzers.Skyrim/Extensions/WorldspaceExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using Mutagen.Bethesda.Plugins.Cache;
 using Mutagen.Bethesda.Skyrim;
+
 namespace Mutagen.Bethesda.Analyzers.Skyrim.Extensions;
 
 public static class WorldspaceExtensions

--- a/Mutagen.Bethesda.Analyzers.Skyrim/Record/Cell/Interior/Settlement/DoorAnalyzer.cs
+++ b/Mutagen.Bethesda.Analyzers.Skyrim/Record/Cell/Interior/Settlement/DoorAnalyzer.cs
@@ -1,6 +1,7 @@
 ﻿using Mutagen.Bethesda.Analyzers.SDK.Analyzers;
 using Mutagen.Bethesda.Analyzers.SDK.Topics;
 using Mutagen.Bethesda.Skyrim;
+
 namespace Mutagen.Bethesda.Analyzers.Skyrim.Record.Cell.Interior.Settlement;
 
 public class DoorAnalyzer : IContextualRecordAnalyzer<ICellGetter>

--- a/Mutagen.Bethesda.Analyzers.Skyrim/Record/Cell/Interior/Settlement/NoBossLocRefTypeAnalyzer.cs
+++ b/Mutagen.Bethesda.Analyzers.Skyrim/Record/Cell/Interior/Settlement/NoBossLocRefTypeAnalyzer.cs
@@ -1,6 +1,7 @@
 ﻿using Mutagen.Bethesda.Analyzers.SDK.Analyzers;
 using Mutagen.Bethesda.Analyzers.SDK.Topics;
 using Mutagen.Bethesda.Skyrim;
+
 namespace Mutagen.Bethesda.Analyzers.Skyrim.Record.Cell.Interior.Settlement;
 
 public class NoBossLocRefTypeAnalyzer : IContextualRecordAnalyzer<ICellGetter>

--- a/Mutagen.Bethesda.Analyzers.Skyrim/Record/Npc/CarryPackageAnalyzer.cs
+++ b/Mutagen.Bethesda.Analyzers.Skyrim/Record/Npc/CarryPackageAnalyzer.cs
@@ -17,12 +17,12 @@ public class CarryPackageAnalyzer : IContextualRecordAnalyzer<INpcGetter>
             Severity.Warning)
         .WithoutFormatting("Npc uses carry package, but doesn't have StopCarryingEvent property in carry script filled");
 
-    public static readonly TopicDefinition< IFormLinkGetter<ISkyrimMajorRecordGetter>> StopCarryingEventPropertyNotIdleAnimation = MutagenTopicBuilder.DevelopmentTopic(
+    public static readonly TopicDefinition<IFormLinkGetter<ISkyrimMajorRecordGetter>> StopCarryingEventPropertyNotIdleAnimation = MutagenTopicBuilder.DevelopmentTopic(
             "Carry package with wrong StopCarryingEvent property",
             Severity.Warning)
         .WithFormatting< IFormLinkGetter<ISkyrimMajorRecordGetter>>("Npc uses carry package, but StopCarryingEvent property in carry script is not set to OffsetStop but {0}");
 
-    public static readonly TopicDefinition< IFormLinkGetter<ISkyrimMajorRecordGetter>> NoCarryItemProperty = MutagenTopicBuilder.DevelopmentTopic(
+    public static readonly TopicDefinition<IFormLinkGetter<ISkyrimMajorRecordGetter>> NoCarryItemProperty = MutagenTopicBuilder.DevelopmentTopic(
             "Carry package without CarryItem property",
             Severity.Warning)
         .WithFormatting< IFormLinkGetter<ISkyrimMajorRecordGetter>>("Npc uses carry package, but has no CarryItem property filled");

--- a/Mutagen.Bethesda.Analyzers.Skyrim/Record/Npc/Unique/NoItemsAnalyzer.cs
+++ b/Mutagen.Bethesda.Analyzers.Skyrim/Record/Npc/Unique/NoItemsAnalyzer.cs
@@ -1,6 +1,7 @@
 using Mutagen.Bethesda.Analyzers.SDK.Analyzers;
 using Mutagen.Bethesda.Analyzers.SDK.Topics;
 using Mutagen.Bethesda.Skyrim;
+
 namespace Mutagen.Bethesda.Analyzers.Skyrim.Record.Npc.Unique;
 
 public class NoItemsAnalyzer : IIsolatedRecordAnalyzer<INpcGetter>

--- a/Mutagen.Bethesda.Analyzers.Skyrim/Record/Npc/Unique/UniqueNpcsConstants.cs
+++ b/Mutagen.Bethesda.Analyzers.Skyrim/Record/Npc/Unique/UniqueNpcsConstants.cs
@@ -1,4 +1,5 @@
 ﻿using Mutagen.Bethesda.Skyrim;
+
 namespace Mutagen.Bethesda.Analyzers.Skyrim.Record.Npc.Unique;
 
 public static class UniqueNpcsConstants

--- a/Mutagen.Bethesda.Analyzers.Skyrim/Record/Quest/StoryManagerQuestAnalyzer.cs
+++ b/Mutagen.Bethesda.Analyzers.Skyrim/Record/Quest/StoryManagerQuestAnalyzer.cs
@@ -1,7 +1,6 @@
 ﻿using Mutagen.Bethesda.Analyzers.SDK.Analyzers;
 using Mutagen.Bethesda.Analyzers.SDK.Topics;
 using Mutagen.Bethesda.Skyrim;
-using Noggog;
 
 namespace Mutagen.Bethesda.Analyzers.Skyrim.Record.Quest;
 

--- a/Mutagen.Bethesda.Analyzers.Testing/AutoFixture/AnalyzerAutoData.cs
+++ b/Mutagen.Bethesda.Analyzers.Testing/AutoFixture/AnalyzerAutoData.cs
@@ -5,6 +5,7 @@ using Mutagen.Bethesda.Analyzers.Testing.AutoFixture;
 using Mutagen.Bethesda.Testing.AutoData;
 using Noggog.Testing.AutoFixture;
 using Xunit;
+
 namespace Mutagen.Bethesda.Analyzers.Tests;
 
 public class AnalyzerAutoData : AutoDataAttribute

--- a/Mutagen.Bethesda.Analyzers.Testing/TestModule.cs
+++ b/Mutagen.Bethesda.Analyzers.Testing/TestModule.cs
@@ -3,7 +3,6 @@ using Autofac;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Mutagen.Bethesda.Analyzers.Cli.Modules;
-using Mutagen.Bethesda.Analyzers.Config;
 using Mutagen.Bethesda.Analyzers.Config.Topic;
 using Mutagen.Bethesda.Analyzers.SDK.Topics;
 using Mutagen.Bethesda.Environments.DI;

--- a/Mutagen.Bethesda.Analyzers.Tests/Config/RunConfigReaderTests.cs
+++ b/Mutagen.Bethesda.Analyzers.Tests/Config/RunConfigReaderTests.cs
@@ -5,7 +5,6 @@ using Mutagen.Bethesda.Analyzers.Config;
 using Mutagen.Bethesda.Analyzers.Config.Run;
 using Mutagen.Bethesda.FormKeys.SkyrimSE;
 using Noggog.Testing.IO;
-using NSubstitute;
 using Xunit;
 
 namespace Mutagen.Bethesda.Analyzers.Tests.Config;

--- a/Mutagen.Bethesda.Analyzers.Tests/Engine/Reporting/EditorIdEnricherTests.cs
+++ b/Mutagen.Bethesda.Analyzers.Tests/Engine/Reporting/EditorIdEnricherTests.cs
@@ -1,4 +1,3 @@
-using AutoFixture.Xunit2;
 using FluentAssertions;
 using Mutagen.Bethesda.Analyzers.Reporting.Drops;
 using Mutagen.Bethesda.Analyzers.SDK.Drops;

--- a/Mutagen.Bethesda.Analyzers.Tests/Integration/RunConfigApplicationTests.cs
+++ b/Mutagen.Bethesda.Analyzers.Tests/Integration/RunConfigApplicationTests.cs
@@ -1,6 +1,5 @@
 using Autofac;
 using FluentAssertions;
-using Mutagen.Bethesda.Analyzers.Config.Run;
 using Mutagen.Bethesda.Analyzers.Config.Topic;
 using Mutagen.Bethesda.Analyzers.Engines;
 using Mutagen.Bethesda.Analyzers.SDK.Analyzers;


### PR DESCRIPTION
Adds `IBlacklistedModsProvider` to exclude mods that shouldn't be analyzed.

For `ContextualAnalyzer` it just filters outgoing reports, as they might use records from these mods in their own analyze logic.