### PR TITLE
Add launchSettings.json to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -386,3 +386,6 @@ FodyWeavers.xsd
 # JetBrains Rider
 .idea/
 *.sln.iml
+
+# User specific launch settings when starting from the IDE
+/Mutagen.Bethesda.Analyzers.Cli/Properties/launchSettings.json


### PR DESCRIPTION
Add launchSettings.json to .gitignore. This file is used by Visual Studio/Rider to set command line arguments and other settings that are always user specific.