### PR TITLE
AliasIDAnalyzer

### DIFF
--- a/Mutagen.Bethesda.Analyzers.Skyrim.Tests/IsolatedRecords/Npcs/AmbushAnalyzerTest.cs
+++ b/Mutagen.Bethesda.Analyzers.Skyrim.Tests/IsolatedRecords/Npcs/AmbushAnalyzerTest.cs
@@ -1,5 +1,5 @@
 
-using Mutagen.Bethesda.Analyzers.Skyrim.Record.Npcs;
+using Mutagen.Bethesda.Analyzers.Skyrim.Record.Npc;
 using Mutagen.Bethesda.Analyzers.Testing.Frameworks;
 using Mutagen.Bethesda.Skyrim;
 using Mutagen.Bethesda.Testing.AutoData;

--- a/Mutagen.Bethesda.Analyzers.Skyrim.Tests/IsolatedRecords/Quests/AliasIDAnalyzerTest.cs
+++ b/Mutagen.Bethesda.Analyzers.Skyrim.Tests/IsolatedRecords/Quests/AliasIDAnalyzerTest.cs
@@ -1,0 +1,106 @@
+using Mutagen.Bethesda.Analyzers.Skyrim.Record.Quest;
+using Mutagen.Bethesda.Analyzers.Testing.Frameworks;
+using Mutagen.Bethesda.Skyrim;
+using Mutagen.Bethesda.Testing.AutoData;
+using Xunit;
+
+namespace Mutagen.Bethesda.Analyzers.Skyrim.Tests.IsolatedRecords.Quests;
+
+public class AliasIDAnalyzerTest
+{
+    [Theory, MutagenModAutoData]
+    public void TestNextAliasIDAlreadyInUse(
+        IsolatedRecordTestFixture<AliasIDAnalyzer, Quest, IQuestGetter> fixture)
+    {
+        fixture.Run(
+            prepForError: rec =>
+            {
+                rec.Aliases.Add(new QuestAlias{ID = 0});
+                rec.NextAliasID = 0;
+            },
+            prepForFix: rec =>
+            {
+                rec.Aliases.Add(new QuestAlias { ID = 0 });
+                rec.NextAliasID = 1;
+            },
+            AliasIDAnalyzer.NextAliasIDAlreadyInUse);
+    }
+
+    [Theory, MutagenModAutoData]
+    public void TestAliasIDDuplicate(
+    IsolatedRecordTestFixture<AliasIDAnalyzer, Quest, IQuestGetter> fixture)
+    {
+        fixture.Run(
+            prepForError: rec =>
+            {
+                rec.Aliases.Add(new QuestAlias { ID = 0 });
+                rec.Aliases.Add(new QuestAlias { ID = 0 });
+                rec.NextAliasID = 2;
+            },
+            prepForFix: rec =>
+            {
+                rec.Aliases.Add(new QuestAlias { ID = 0 });
+                rec.Aliases.Add(new QuestAlias { ID = 1 });
+                rec.NextAliasID = 2;
+            },
+            AliasIDAnalyzer.AliasIDDuplicate);
+    }
+
+    [Theory, MutagenModAutoData]
+    public void TestAliasReferencesSelf(
+    IsolatedRecordTestFixture<AliasIDAnalyzer, Quest, IQuestGetter> fixture)
+    {
+        fixture.Run(
+            prepForError: rec =>
+            {
+                rec.Aliases.Add(new QuestAlias { ID = 0 });
+                rec.Aliases.Add(new QuestAlias{
+                    ID = 1,
+                    CreateReferenceToObject = new CreateReferenceToObject
+                    {
+                        AliasID = 1,
+                    }
+                });
+                rec.NextAliasID = 2;
+            },
+            prepForFix: rec =>
+            {
+                rec.Aliases.Add(new QuestAlias { ID = 0 });
+                rec.Aliases.Add(new QuestAlias
+                {
+                    ID = 1,
+                    CreateReferenceToObject = new CreateReferenceToObject { AliasID = 0 }
+                });
+                rec.NextAliasID = 2;
+            },
+            AliasIDAnalyzer.AliasReferencesSelf);
+    }
+
+    [Theory, MutagenModAutoData]
+    public void TestAliasReferenceNotPreviousAlias(
+    IsolatedRecordTestFixture<AliasIDAnalyzer, Quest, IQuestGetter> fixture)
+    {
+        fixture.Run(
+            prepForError: rec =>
+            {
+                rec.Aliases.Add(new QuestAlias
+                {
+                    ID = 1,
+                    Location = new LocationAliasReference { AliasID = 0 }
+                });
+                rec.Aliases.Add(new QuestAlias { ID = 0 });
+                rec.NextAliasID = 2;
+            },
+            prepForFix: rec =>
+            {
+                rec.Aliases.Add(new QuestAlias { ID = 0 });
+                rec.Aliases.Add(new QuestAlias
+                {
+                    ID = 1,
+                    Location = new LocationAliasReference { AliasID = 0 }
+                });
+                rec.NextAliasID = 2;
+            },
+            AliasIDAnalyzer.AliasReferenceNotPreviousAlias);
+    }
+}

--- a/Mutagen.Bethesda.Analyzers.Skyrim/Record/Npc/AmbushAnalyzer.cs
+++ b/Mutagen.Bethesda.Analyzers.Skyrim/Record/Npc/AmbushAnalyzer.cs
@@ -2,7 +2,7 @@ using Mutagen.Bethesda.Analyzers.SDK.Analyzers;
 using Mutagen.Bethesda.Analyzers.SDK.Topics;
 using Mutagen.Bethesda.Skyrim;
 
-namespace Mutagen.Bethesda.Analyzers.Skyrim.Record.Npcs;
+namespace Mutagen.Bethesda.Analyzers.Skyrim.Record.Npc;
 
 public class AmbushAnalyzer : IIsolatedRecordAnalyzer<INpcGetter>
 {

--- a/Mutagen.Bethesda.Analyzers.Skyrim/Record/Quest/AliasIDAnalyzer.cs
+++ b/Mutagen.Bethesda.Analyzers.Skyrim/Record/Quest/AliasIDAnalyzer.cs
@@ -18,19 +18,23 @@ public class AliasIDAnalyzer : IIsolatedRecordAnalyzer<IQuestGetter>
             Severity.Error)
         .WithFormatting<int>("AliasID {0} is used multiple times in the same quest");
 
-    public static readonly TopicDefinition<string?> AliasReferencesSelf = MutagenTopicBuilder.FromDiscussion(
+    public static readonly TopicDefinition<string?, string> AliasReferencesSelf = MutagenTopicBuilder.FromDiscussion(
             181,
             "Alias references self",
             Severity.Error)
-        .WithFormatting<string?>("Alias {0} references itself");
+        .WithFormatting<string?, string>("Alias {0} references itself in {1}");
 
-    public static readonly TopicDefinition<string?, uint> AliasReferenceNotPreviousAlias = MutagenTopicBuilder.FromDiscussion(
+    public static readonly TopicDefinition<string?, uint, string, string> AliasReferenceNotPreviousAlias = MutagenTopicBuilder.FromDiscussion(
             182,
             "Alias reference not previous alias",
             Severity.Error)
-        .WithFormatting<string?, uint>("Alias {0} references AliasID {1} that is not among the previous aliases");
+        .WithFormatting<string?, uint, string, string>("Alias {0} references AliasID {1} {2} in {3} that is not defined earlier");
 
     IEnumerable<TopicDefinition> IAnalyzer.Topics { get; } = [NextAliasIDAlreadyInUse, AliasIDDuplicate, AliasReferencesSelf, AliasReferenceNotPreviousAlias];
+
+    private static readonly string aliasrefSourceLocation = "'Fill Type - Location Alias Reference'";
+    private static readonly string aliasrefSourceCreate = "'Fill Type - Create Reference To Object";
+    private static readonly string aliasrefSourceMatchingRef = "'Fill Type - Find Matchning Reference Near Alias'";
 
     void IIsolatedRecordAnalyzer<IQuestGetter>.AnalyzeRecord(IsolatedRecordAnalyzerParams<IQuestGetter> param)
     {
@@ -41,22 +45,28 @@ public class AliasIDAnalyzer : IIsolatedRecordAnalyzer<IQuestGetter>
             param.AddTopic(NextAliasIDAlreadyInUse.Format());
         }
 
+        Dictionary<uint, IQuestAliasGetter> aliases = [];
+        foreach (IQuestAliasGetter alias in quest.Aliases)
+        {
+            _ = aliases.TryAdd(alias.ID, alias);
+        }
+
         HashSet<uint> ids = [];
         foreach(IQuestAliasGetter alias in quest.Aliases)
         {
             if (alias.Location != null)
             {
-                CheckAliasAlreadyDefined(param, alias.Location.AliasID, alias, ids);
+                CheckAliasAlreadyDefined(aliasrefSourceLocation, param, alias.Location.AliasID, alias, ids, aliases);
             }
 
             if (alias.CreateReferenceToObject != null)
             {
-                CheckAliasAlreadyDefined(param, alias.CreateReferenceToObject.AliasID, alias, ids);
+                CheckAliasAlreadyDefined(aliasrefSourceCreate, param, alias.CreateReferenceToObject.AliasID, alias, ids, aliases);
             }
 
             if (alias.FindMatchingRefNearAlias != null)
             {
-                CheckAliasAlreadyDefined(param, alias.FindMatchingRefNearAlias.AliasID, alias, ids);
+                CheckAliasAlreadyDefined(aliasrefSourceMatchingRef,param, alias.FindMatchingRefNearAlias.AliasID, alias, ids, aliases);
             }
 
             if(!ids.Add(alias.ID))
@@ -66,32 +76,46 @@ public class AliasIDAnalyzer : IIsolatedRecordAnalyzer<IQuestGetter>
         }
     }
 
-    private static void CheckAliasAlreadyDefined(IsolatedRecordAnalyzerParams<IQuestGetter> param, uint idToCheck, IQuestAliasGetter currentAlias, HashSet<uint> previousIds)
+    private static void CheckAliasAlreadyDefined(string refSource, IsolatedRecordAnalyzerParams<IQuestGetter> param, uint idToCheck, IQuestAliasGetter currentAlias, HashSet<uint> previousIds, Dictionary<uint, IQuestAliasGetter> aliases)
     {
         if (idToCheck == currentAlias.ID)
         {
-            param.AddTopic(AliasReferencesSelf.Format(currentAlias.Name));
+            param.AddTopic(AliasReferencesSelf.Format(currentAlias.Name, refSource));
         }
         else if (!previousIds.Contains(idToCheck))
         {
-            param.AddTopic(AliasReferenceNotPreviousAlias.Format(currentAlias.Name, idToCheck));
+            param.AddTopic(AliasReferenceNotPreviousAlias.Format(
+                currentAlias.Name,
+                idToCheck,
+                GetReferencedAliasName(idToCheck, aliases),
+                refSource));
         }
     }
 
-    private static void CheckAliasAlreadyDefined(IsolatedRecordAnalyzerParams<IQuestGetter> param, int? idToCheck, IQuestAliasGetter currentAlias, HashSet<uint> previousIds)
+    private static void CheckAliasAlreadyDefined(string refSource, IsolatedRecordAnalyzerParams<IQuestGetter> param, int? idToCheck, IQuestAliasGetter currentAlias, HashSet<uint> previousIds, Dictionary<uint, IQuestAliasGetter> aliases)
     {
         if (idToCheck != null)
         {
-            CheckAliasAlreadyDefined(param, Convert.ToUInt32(idToCheck), currentAlias, previousIds);
+            CheckAliasAlreadyDefined(refSource, param, Convert.ToUInt32(idToCheck), currentAlias, previousIds, aliases);
         }
     }
 
-    private static void CheckAliasAlreadyDefined(IsolatedRecordAnalyzerParams<IQuestGetter> param, short? idToCheck, IQuestAliasGetter currentAlias, HashSet<uint> previousIds)
+    private static void CheckAliasAlreadyDefined(string refSource, IsolatedRecordAnalyzerParams<IQuestGetter> param, short? idToCheck, IQuestAliasGetter currentAlias, HashSet<uint> previousIds, Dictionary<uint, IQuestAliasGetter> aliases)
     {
         if (idToCheck != null)
         {
-            CheckAliasAlreadyDefined(param, Convert.ToUInt32(idToCheck), currentAlias, previousIds);
+            CheckAliasAlreadyDefined(refSource, param, Convert.ToUInt32(idToCheck), currentAlias, previousIds, aliases);
         }
+    }
+
+    private static string GetReferencedAliasName(uint idToCheck, Dictionary<uint, IQuestAliasGetter> aliases)
+    {
+        IQuestAliasGetter? referencedAlias;
+        if (aliases.TryGetValue(idToCheck, out referencedAlias) && (referencedAlias.Name != null))
+        {
+            return referencedAlias.Name;
+        }
+        return "[[MISSING]]";
     }
 
     IEnumerable<Func<IQuestGetter, object?>> IIsolatedRecordAnalyzer<IQuestGetter>.FieldsOfInterest()

--- a/Mutagen.Bethesda.Analyzers.Skyrim/Record/Quest/AliasIDAnalyzer.cs
+++ b/Mutagen.Bethesda.Analyzers.Skyrim/Record/Quest/AliasIDAnalyzer.cs
@@ -1,0 +1,103 @@
+using Mutagen.Bethesda.Analyzers.SDK.Analyzers;
+using Mutagen.Bethesda.Analyzers.SDK.Topics;
+using Mutagen.Bethesda.Skyrim;
+
+namespace Mutagen.Bethesda.Analyzers.Skyrim.Record.Quest;
+
+public class AliasIDAnalyzer : IIsolatedRecordAnalyzer<IQuestGetter>
+{
+    public static readonly TopicDefinition NextAliasIDAlreadyInUse = MutagenTopicBuilder.FromDiscussion(
+            179,
+            "NextAliasID in use",
+            Severity.Error)
+        .WithoutFormatting("NextAliasID is equal or smaller than ID of existing alias");
+
+    public static readonly TopicDefinition<int> AliasIDDuplicate = MutagenTopicBuilder.FromDiscussion(
+            180,
+            "AliasID duplicate",
+            Severity.Error)
+        .WithFormatting<int>("AliasID {0} is used multiple times in the same quest");
+
+    public static readonly TopicDefinition<string?> AliasReferencesSelf = MutagenTopicBuilder.FromDiscussion(
+            181,
+            "Alias references self",
+            Severity.Error)
+        .WithFormatting<string?>("Alias {0} references itself");
+
+    public static readonly TopicDefinition<string?, uint> AliasReferenceNotPreviousAlias = MutagenTopicBuilder.FromDiscussion(
+            182,
+            "Alias reference not previous alias",
+            Severity.Error)
+        .WithFormatting<string?, uint>("Alias {0} references AliasID {1} that is not among the previous aliases");
+
+    IEnumerable<TopicDefinition> IAnalyzer.Topics { get; } = [NextAliasIDAlreadyInUse, AliasIDDuplicate, AliasReferencesSelf, AliasReferenceNotPreviousAlias];
+
+    void IIsolatedRecordAnalyzer<IQuestGetter>.AnalyzeRecord(IsolatedRecordAnalyzerParams<IQuestGetter> param)
+    {
+        var quest = param.Record;
+
+        if (quest.Aliases.Any(a => a.ID >= quest.NextAliasID))
+        {
+            param.AddTopic(NextAliasIDAlreadyInUse.Format());
+        }
+
+        HashSet<uint> ids = [];
+        foreach(IQuestAliasGetter alias in quest.Aliases)
+        {
+            if (alias.Location != null)
+            {
+                CheckAliasAlreadyDefined(param, alias.Location.AliasID, alias, ids);
+            }
+
+            if (alias.CreateReferenceToObject != null)
+            {
+                CheckAliasAlreadyDefined(param, alias.CreateReferenceToObject.AliasID, alias, ids);
+            }
+
+            if (alias.FindMatchingRefNearAlias != null)
+            {
+                CheckAliasAlreadyDefined(param, alias.FindMatchingRefNearAlias.AliasID, alias, ids);
+            }
+
+            if(!ids.Add(alias.ID))
+            {
+                param.AddTopic(AliasIDDuplicate.Format());
+            }
+        }
+    }
+
+    private static void CheckAliasAlreadyDefined(IsolatedRecordAnalyzerParams<IQuestGetter> param, uint idToCheck, IQuestAliasGetter currentAlias, HashSet<uint> previousIds)
+    {
+        if (idToCheck == currentAlias.ID)
+        {
+            param.AddTopic(AliasReferencesSelf.Format(currentAlias.Name));
+        }
+        else if (!previousIds.Contains(idToCheck))
+        {
+            param.AddTopic(AliasReferenceNotPreviousAlias.Format(currentAlias.Name, idToCheck));
+        }
+    }
+
+    private static void CheckAliasAlreadyDefined(IsolatedRecordAnalyzerParams<IQuestGetter> param, int? idToCheck, IQuestAliasGetter currentAlias, HashSet<uint> previousIds)
+    {
+        if (idToCheck != null)
+        {
+            CheckAliasAlreadyDefined(param, Convert.ToUInt32(idToCheck), currentAlias, previousIds);
+        }
+    }
+
+    private static void CheckAliasAlreadyDefined(IsolatedRecordAnalyzerParams<IQuestGetter> param, short? idToCheck, IQuestAliasGetter currentAlias, HashSet<uint> previousIds)
+    {
+        if (idToCheck != null)
+        {
+            CheckAliasAlreadyDefined(param, Convert.ToUInt32(idToCheck), currentAlias, previousIds);
+        }
+    }
+
+    IEnumerable<Func<IQuestGetter, object?>> IIsolatedRecordAnalyzer<IQuestGetter>.FieldsOfInterest()
+    {
+        yield return x => x.NextAliasID;
+        yield return x => x.Aliases;
+    }
+}
+


### PR DESCRIPTION
Added AliasIDAnalyzer that checks

- NextAliasID <= ID already in use for this quest
- Duplicate AliasID
- Alias references itself
- Alias reference another alias that is not defined earlier

Fix namespace of AmbushAnalyzer