### PR TITLE
fix: handle data folder when --DataFolder is provided

### DIFF
--- a/Mutagen.Bethesda.Analyzers.Cli/RunAnalyzers.cs
+++ b/Mutagen.Bethesda.Analyzers.Cli/RunAnalyzers.cs
@@ -78,9 +78,15 @@ public static class RunAnalyzers
                 .Select(x => x.Trim())
                 .Select(x => ModKey.FromFileName(x));
 
-            gameEnvironment = GameEnvironmentBuilder.Create(GameRelease.SkyrimSE)
-                .WithLoadOrder(loadOrder.ToArray())
-                .Build();
+            var envBuilder = GameEnvironmentBuilder.Create(command.GameRelease)
+                .WithLoadOrder(loadOrder.ToArray());
+
+            if (command.DataFolder is not null)
+            {
+                envBuilder = envBuilder.WithTargetDataFolder(new DirectoryPath(command.DataFolder));
+            }
+
+            gameEnvironment = envBuilder.Build();
         }
 
         builder


### PR DESCRIPTION
`--DataFolder` argument is not passed to the game environment builder. If the argument is provided, the game's installation folder is used instead of the provided one. Fixes #527.