### PR TITLE
Allow GetStage == 0 even if quest does not have a stage 0

### DIFF
--- a/Mutagen.Bethesda.Analyzers.Skyrim/Record/ConditionAnalyzer.cs
+++ b/Mutagen.Bethesda.Analyzers.Skyrim/Record/ConditionAnalyzer.cs
@@ -88,6 +88,7 @@ public class ConditionAnalyzer : IContextualRecordAnalyzer<ISkyrimMajorRecordGet
                 {
                     if (condition is IConditionFloatGetter floatCondition
                         && getStage.Quest.UsesLink() && getStage.Quest.Link.TryResolve(param.LinkCache, out var quest)
+                        && floatCondition.ComparisonValue != 0
                         && quest.Stages.All(s => s.Index != (int)floatCondition.ComparisonValue))
                     {
                         param.AddTopic(


### PR DESCRIPTION
GetStage returns 0 for quests that have not had any stages set, such as if they are yet to start.