### PR TITLE
Fix checking for errors after prepareForFix

### DIFF
--- a/Mutagen.Bethesda.Analyzers.Skyrim.Tests/IsolatedRecords/Quests/AliasIDAnalyzerTest.cs
+++ b/Mutagen.Bethesda.Analyzers.Skyrim.Tests/IsolatedRecords/Quests/AliasIDAnalyzerTest.cs
@@ -20,7 +20,6 @@ public class AliasIDAnalyzerTest
             },
             prepForFix: rec =>
             {
-                rec.Aliases.Add(new QuestAlias { ID = 0 });
                 rec.NextAliasID = 1;
             },
             AliasIDAnalyzer.NextAliasIDAlreadyInUse);
@@ -39,9 +38,7 @@ public class AliasIDAnalyzerTest
             },
             prepForFix: rec =>
             {
-                rec.Aliases.Add(new QuestAlias { ID = 0 });
-                rec.Aliases.Add(new QuestAlias { ID = 1 });
-                rec.NextAliasID = 2;
+                rec.Aliases[1].ID = 1;
             },
             AliasIDAnalyzer.AliasIDDuplicate);
     }
@@ -65,13 +62,7 @@ public class AliasIDAnalyzerTest
             },
             prepForFix: rec =>
             {
-                rec.Aliases.Add(new QuestAlias { ID = 0 });
-                rec.Aliases.Add(new QuestAlias
-                {
-                    ID = 1,
-                    CreateReferenceToObject = new CreateReferenceToObject { AliasID = 0 }
-                });
-                rec.NextAliasID = 2;
+                rec.Aliases[1].CreateReferenceToObject!.AliasID = 0;
             },
             AliasIDAnalyzer.AliasReferencesSelf);
     }
@@ -93,13 +84,8 @@ public class AliasIDAnalyzerTest
             },
             prepForFix: rec =>
             {
-                rec.Aliases.Add(new QuestAlias { ID = 0 });
-                rec.Aliases.Add(new QuestAlias
-                {
-                    ID = 1,
-                    Location = new LocationAliasReference { AliasID = 0 }
-                });
-                rec.NextAliasID = 2;
+                // Swap aliases 0 and 1 such that 1 is after its dependent alias
+                (rec.Aliases[1], rec.Aliases[0]) = (rec.Aliases[0], rec.Aliases[1]);
             },
             AliasIDAnalyzer.AliasReferenceNotPreviousAlias);
     }

--- a/Mutagen.Bethesda.Analyzers.Testing/Frameworks/IsolatedRecordTestFixture.cs
+++ b/Mutagen.Bethesda.Analyzers.Testing/Frameworks/IsolatedRecordTestFixture.cs
@@ -46,7 +46,7 @@ public class IsolatedRecordTestFixture<TAnalyzer, TMajor, TMajorGetter>
         // ToDo
         // Eventually test that fixrec triggers a rerun in the engine properly
 
-        dropOff = new();
+        dropOff.ClearReports();
         Sut.AnalyzeRecord(param);
         dropOff.Reports.ShouldBeEmpty();
     }

--- a/Mutagen.Bethesda.Analyzers.Testing/TestDropoff.cs
+++ b/Mutagen.Bethesda.Analyzers.Testing/TestDropoff.cs
@@ -10,6 +10,11 @@ public class TestDropoff : IReportDropbox
     private readonly List<Topic> _reports = new();
     public IReadOnlyList<Topic> Reports => _reports;
 
+    public void ClearReports()
+    {
+        _reports.Clear();
+    }
+
     public void Dropoff(ReportContextParameters parameters, ModKey mod, IFormLinkIdentifier record, Topic topic)
     {
         _reports.Add(topic);


### PR DESCRIPTION
dropOff was replaced with a new object without updating the destination of reports. This caused prepareForFix to always succeeed, even if there were still errors.