### PR TITLE
Fix false positive in UniqueNpcPlacementAnalyzer

### DIFF
--- a/Mutagen.Bethesda.Analyzers.Skyrim.Tests/ContextualRecords/Npcs/UniqueNpcPlacementAnalyzerTest.cs
+++ b/Mutagen.Bethesda.Analyzers.Skyrim.Tests/ContextualRecords/Npcs/UniqueNpcPlacementAnalyzerTest.cs
@@ -1,0 +1,104 @@
+using Mutagen.Bethesda.Analyzers.Skyrim.Record.Npc.Unique;
+using Mutagen.Bethesda.Analyzers.Testing.Frameworks;
+using Mutagen.Bethesda.Skyrim;
+using Mutagen.Bethesda.Testing.AutoData;
+using Xunit;
+
+namespace Mutagen.Bethesda.Analyzers.Skyrim.Tests.ContextualRecords.Npcs;
+
+using Fixture = ContextualRecordTestFixture<UniqueNpcPlacementAnalyzer, Npc, INpcGetter>;
+
+public class UniqueNpcPlacementAnalyzerTest
+{
+    // A unique NPC must be placed exactly once
+    [Theory, MutagenModAutoData]
+    public void PlacedMultiple(
+        Fixture fixture)
+    {
+        var cell = fixture.Create<Cell>();
+        var npc1 = fixture.Create<PlacedNpc>();
+        var npc2 = fixture.Create<PlacedNpc>();
+
+        fixture.Run(
+            prepForError: (rec, mod) =>
+            {
+                rec.Configuration.Flags |= NpcConfiguration.Flag.Unique;
+
+                cell.Flags |= Cell.Flag.IsInteriorCell;
+                mod.Cells.AddInteriorCell(cell);
+                npc1.Base.SetTo(rec);
+                cell.Temporary.Add(npc1);
+                npc2.Base.SetTo(rec);
+                cell.Temporary.Add(npc2);
+            },
+            prepForFix: (rec, mod) =>
+            {
+                cell.Temporary.Remove(npc2);
+            },
+            UniqueNpcPlacementAnalyzer.PlacedMultiple);
+    }
+
+    // A unique NPC must be placed exactly once
+    [Theory, MutagenModAutoData]
+    public void PlacedNever(Fixture fixture)
+    {
+        fixture.Run(
+            prepForError: (rec, mod) =>
+            {
+                rec.Configuration.Flags |= NpcConfiguration.Flag.Unique;
+            },
+            prepForFix: (rec, mod) =>
+            {
+                var cell = fixture.Create<Cell>();
+                cell.Flags |= Cell.Flag.IsInteriorCell;
+                mod.Cells.AddInteriorCell(cell);
+                var npc = fixture.Create<PlacedNpc>();
+                npc.Base.SetTo(rec);
+                cell.Temporary.Add(npc);
+            },
+            UniqueNpcPlacementAnalyzer.PlacedNever);
+    }
+
+    // A non-unique NPC may be placed multiple times
+    [Theory, MutagenModAutoData]
+    public void NotUnique(Fixture fixture)
+    {
+        fixture.RunShouldBeNoError((rec, mod) =>
+        {
+            rec.Configuration.Flags &= ~NpcConfiguration.Flag.Unique;
+            var cell = fixture.Create<Cell>();
+            cell.Flags |= Cell.Flag.IsInteriorCell;
+            mod.Cells.AddInteriorCell(cell);
+
+            var npc1 = fixture.Create<PlacedNpc>();
+            npc1.Base.SetTo(rec);
+            cell.Temporary.Add(npc1);
+
+            var npc2 = fixture.Create<PlacedNpc>();
+            npc2.Base.SetTo(rec);
+            cell.Temporary.Add(npc2);
+        });
+    }
+
+    // A unique NPC may be referenced by fields other than PlacedNpc.Base
+    [Theory, MutagenModAutoData]
+    public void ReferencedOtherField(Fixture fixture)
+    {
+        var npc = fixture.Create<Npc>();
+        fixture.RunShouldBeNoError((rec, mod) =>
+        {
+            rec.Configuration.Flags |= NpcConfiguration.Flag.Unique;
+            var cell = fixture.Create<Cell>();
+            cell.Flags |= Cell.Flag.IsInteriorCell;
+            mod.Cells.AddInteriorCell(cell);
+
+            var npc1 = fixture.Create<PlacedNpc>();
+            npc1.Base.SetTo(rec);
+            cell.Temporary.Add(npc1);
+
+            var npc2 = fixture.Create<PlacedNpc>();
+            npc2.Owner.SetTo(rec);
+            cell.Temporary.Add(npc2);
+        });
+    }
+}

--- a/Mutagen.Bethesda.Analyzers.Skyrim/Record/Npc/Unique/UniqueNpcPlacementAnalyzer.cs
+++ b/Mutagen.Bethesda.Analyzers.Skyrim/Record/Npc/Unique/UniqueNpcPlacementAnalyzer.cs
@@ -25,12 +25,11 @@ public class UniqueNpcPlacementAnalyzer : IContextualRecordAnalyzer<INpcGetter>
     public void AnalyzeRecord(ContextualRecordAnalyzerParams<INpcGetter> param)
     {
         var npc = param.Record;
-        if (!npc.IsUniqueActorType(param.LinkCache)) return;
+        if (!npc.IsUnique()) return;
 
         var placements = param.ResolveCache<ILinkUsageCache>()
             .GetUsagesOf<IPlacedNpcGetter>(npc).UsageLinks
-            .Select(p => p.TryResolve(param.LinkCache))
-            .WhereNotNull()
+            .Select(p => p.Resolve(param.LinkCache))
             .Where(p => p.Base.Equals(npc))
             .ToArray();
 

--- a/Mutagen.Bethesda.Analyzers.Skyrim/Record/Npc/Unique/UniqueNpcPlacementAnalyzer.cs
+++ b/Mutagen.Bethesda.Analyzers.Skyrim/Record/Npc/Unique/UniqueNpcPlacementAnalyzer.cs
@@ -1,4 +1,4 @@
-﻿using Mutagen.Bethesda.Analyzers.SDK.Analyzers;
+using Mutagen.Bethesda.Analyzers.SDK.Analyzers;
 using Mutagen.Bethesda.Analyzers.SDK.Topics;
 using Mutagen.Bethesda.Plugins.Cache;
 using Mutagen.Bethesda.Skyrim;
@@ -29,6 +29,9 @@ public class UniqueNpcPlacementAnalyzer : IContextualRecordAnalyzer<INpcGetter>
 
         var placements = param.ResolveCache<ILinkUsageCache>()
             .GetUsagesOf<IPlacedNpcGetter>(npc).UsageLinks
+            .Select(p => p.TryResolve(param.LinkCache))
+            .WhereNotNull()
+            .Where(p => p.Base.Equals(npc))
             .ToArray();
 
         switch (placements.Length)
@@ -39,8 +42,6 @@ public class UniqueNpcPlacementAnalyzer : IContextualRecordAnalyzer<INpcGetter>
                 break;
             case > 1:
                 var notDeadNpcs = placements
-                    .Select(p => p.TryResolve(param.LinkCache))
-                    .WhereNotNull()
                     .Where(p => !p.MajorFlags.HasFlag(PlacedNpc.MajorFlag.StartsDead))
                     .ToArray();
 

--- a/Mutagen.Bethesda.Analyzers.Testing/Frameworks/ContextualRecordTestFixture.cs
+++ b/Mutagen.Bethesda.Analyzers.Testing/Frameworks/ContextualRecordTestFixture.cs
@@ -1,0 +1,105 @@
+using AutoFixture;
+using Mutagen.Bethesda.Analyzers.Drivers;
+using Mutagen.Bethesda.Analyzers.SDK.Analyzers;
+using Mutagen.Bethesda.Analyzers.SDK.Topics;
+using Mutagen.Bethesda.Analyzers.Skyrim.Caches;
+using Mutagen.Bethesda.Plugins;
+using Mutagen.Bethesda.Plugins.Cache;
+using Mutagen.Bethesda.Plugins.Order;
+using Mutagen.Bethesda.Plugins.Records;
+using Mutagen.Bethesda.Skyrim;
+using Noggog.Testing.Extensions;
+using Shouldly;
+
+namespace Mutagen.Bethesda.Analyzers.Testing.Frameworks;
+
+public class ContextualRecordTestFixture<TAnalyzer, TMajor, TMajorGetter>
+    where TMajor : IMajorRecord, TMajorGetter
+    where TMajorGetter : IMajorRecordGetter
+    where TAnalyzer : IContextualRecordAnalyzer<TMajorGetter>
+{
+    private readonly IFixture _fixture;
+    public TAnalyzer Sut { get; }
+
+    public ContextualRecordTestFixture(TAnalyzer sut, IFixture fixture)
+    {
+        _fixture = fixture;
+        Sut = sut;
+    }
+
+    readonly struct TestParameters
+    {
+        public ISkyrimMod Mod { get; init; }
+        public TMajor Rec { get; init; }
+        public ILoadOrder<IModListing<ISkyrimMod>> LoadOrder { get; init; }
+        public ILinkCache LinkCache { get; init; }
+        public TestDropoff DropOff { get; init; }
+    };
+
+    public T Create<T>() where T : IMajorRecord => _fixture.Create<T>();
+
+    ContextualRecordAnalyzerParams<TMajorGetter> CreateAnalyserParams(TestParameters baseParams)
+    {
+        return new ContextualRecordAnalyzerParams<TMajorGetter>(
+            linkCache: baseParams.LinkCache,
+            loadOrder: baseParams.LoadOrder,
+            modKey: ModKey.Null,
+            record: baseParams.Rec,
+            reportDropbox: baseParams.DropOff,
+            // Usage caches are always immutable, therefore we need a new cache after prepForFix
+            provideCaches: new ProvideCaches(baseParams.LinkCache, [new UsageCacheProvider()]));
+    }
+
+    TestParameters Setup()
+    {
+        var mod = new SkyrimMod(ModKey.Null, SkyrimRelease.SkyrimSE);
+        // TODO: Insert record into mod. GetTopLevelGroup returns a getter
+        var rec = _fixture.Create<TMajor>();
+        var loadOrder = new LoadOrder<IModListing<ISkyrimMod>>
+        {
+            new ModListing<ISkyrimMod>(mod)
+        };
+        var linkCache = loadOrder.ToMutableLinkCache();
+        var dropOff = new TestDropoff();
+        return new TestParameters()
+        {
+            Mod = mod,
+            Rec = rec,
+            LoadOrder = loadOrder,
+            LinkCache = linkCache,
+            DropOff = dropOff
+        };
+    }
+
+    public void Run(
+        Action<TMajor, ISkyrimMod> prepForError,
+        Action<TMajor, ISkyrimMod> prepForFix,
+        params TopicDefinition[] expectedTopics)
+    {
+        var param = Setup();
+
+        prepForError(param.Rec, param.Mod);
+
+        Sut.AnalyzeRecord(CreateAnalyserParams(param));
+        param.DropOff.Reports.Select(x => x.TopicDefinition.Id)
+            .ShouldEqualEnumerable(expectedTopics.Select(x => x.Id));
+
+        prepForFix(param.Rec, param.Mod);
+
+        // ToDo
+        // Eventually test that fixrec triggers a rerun in the engine properly
+
+        param.DropOff.ClearReports();
+        Sut.AnalyzeRecord(CreateAnalyserParams(param));
+        param.DropOff.Reports.ShouldBeEmpty();
+    }
+
+    public void RunShouldBeNoError(
+        Action<TMajor, ISkyrimMod> prep)
+    {
+        var param = Setup();
+        prep(param.Rec, param.Mod);
+        Sut.AnalyzeRecord(CreateAnalyserParams(param));
+        param.DropOff.Reports.ShouldBeEmpty();
+    }
+}


### PR DESCRIPTION
Analyser was checking for PlacedNpcs referencing a unique NPC rather than PlacedNpcs with a base of a unique NPC. This caused false positive if other fields, such as an animal's owner, reference a unique NPC.

An example of this in vanilla is Bjorlam, who has exactly one reference but owns his carriage's horse.