### PR TITLE
Fix DetectsExteriorCellWithEncounterZone test

### DIFF
--- a/Mutagen.Bethesda.Analyzers.Skyrim.Tests/IsolatedRecords/Cells/Exterior/EncounterZoneAnalyzerTest.cs
+++ b/Mutagen.Bethesda.Analyzers.Skyrim.Tests/IsolatedRecords/Cells/Exterior/EncounterZoneAnalyzerTest.cs
@@ -20,7 +20,7 @@ public class EncounterZoneAnalyzerTest
             },
             prepForFix: rec =>
             {
-                //nothing to set up, Cell by default is Exterior without Encounter Zone
+                rec.EncounterZone.SetToNull();
             },
             new[]
             {


### PR DESCRIPTION
This was not caught initally as #556 was based on an older commit where fixtures did not properly check for errors not appearing after prepForFix (#557)