### PR TITLE
Fix missing assets analyzers

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -18,12 +18,12 @@
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.9" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="9.0.9" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-    <PackageVersion Include="Mutagen.Bethesda" Version="0.54.0-alpha.22" />
-    <PackageVersion Include="Mutagen.Bethesda.Autofac" Version="0.54.0-alpha.22" />
-    <PackageVersion Include="Mutagen.Bethesda.Core" Version="0.54.0-alpha.22" />
+    <PackageVersion Include="Mutagen.Bethesda" Version="0.54.0-alpha.86" />
+    <PackageVersion Include="Mutagen.Bethesda.Autofac" Version="0.54.0-alpha.86" />
+    <PackageVersion Include="Mutagen.Bethesda.Core" Version="0.54.0-alpha.86" />
     <PackageVersion Include="Mutagen.Bethesda.FormKeys.SkyrimSE" Version="3.4.0" />
-    <PackageVersion Include="Mutagen.Bethesda.Skyrim" Version="0.54.0-alpha.22" />
-    <PackageVersion Include="Mutagen.Bethesda.Testing" Version="0.54.0-alpha.22" />
+    <PackageVersion Include="Mutagen.Bethesda.Skyrim" Version="0.54.0-alpha.86" />
+    <PackageVersion Include="Mutagen.Bethesda.Testing" Version="0.54.0-alpha.86" />
     <PackageVersion Include="Nifly" Version="1.0.0" />
     <PackageVersion Include="Octokit.GraphQL" Version="0.4.0-beta" />
     <PackageVersion Include="xunit" Version="2.9.3" />

--- a/Mutagen.Bethesda.Analyzers.Skyrim.Tests/IsolatedRecords/Quests/AliasForcedNoneAnalyzerTest.cs
+++ b/Mutagen.Bethesda.Analyzers.Skyrim.Tests/IsolatedRecords/Quests/AliasForcedNoneAnalyzerTest.cs
@@ -107,8 +107,7 @@ namespace Mutagen.Bethesda.Analyzers.Skyrim.Tests.IsolatedRecords.Quests
                     rec.Aliases[0].FindMatchingRefFromEvent = new()
                     {
                         FromEvent = new RecordType("SCPT"),
-                        // Script event - Ref1
-                        EventData = new byte[] { 0x52, 0x31, 0x00, 0x00 }
+                        EventData = GetEventDataConditionData.EventMember.Value1
                     };
                 });
         }

--- a/Mutagen.Bethesda.Analyzers.Skyrim/Util/MissingAssetsAnalyzerUtil.cs
+++ b/Mutagen.Bethesda.Analyzers.Skyrim/Util/MissingAssetsAnalyzerUtil.cs
@@ -1,6 +1,9 @@
-﻿using System.IO.Abstractions;
+using System.Diagnostics.CodeAnalysis;
+using System.IO.Abstractions;
 using Mutagen.Bethesda.Analyzers.SDK.Analyzers;
 using Mutagen.Bethesda.Analyzers.SDK.Topics;
+using Mutagen.Bethesda.Environments.DI;
+using Mutagen.Bethesda.Plugins.Assets;
 using Mutagen.Bethesda.Plugins.Records;
 using Mutagen.Bethesda.Skyrim;
 
@@ -9,10 +12,12 @@ namespace Mutagen.Bethesda.Analyzers.Skyrim.Util;
 public class MissingAssetsAnalyzerUtil
 {
     private readonly IFileSystem _fileSystem;
+    private readonly IDataDirectoryProvider _dataDirectory;
 
-    public MissingAssetsAnalyzerUtil(IFileSystem fileSystem)
+    public MissingAssetsAnalyzerUtil(IFileSystem fileSystem, IDataDirectoryProvider dataDirectory)
     {
         _fileSystem = fileSystem;
+        _dataDirectory = dataDirectory;
     }
 
     public void CheckForMissingModelAsset<TMajorRecordGetter>(
@@ -27,6 +32,6 @@ public class MissingAssetsAnalyzerUtil
         param.AddTopic(topicDefinition.Format(path));
     }
 
-    public bool FileExists(string path) => _fileSystem.File.Exists(path);
-    public bool FileExistsIfNotNull(string? path) => path == null || _fileSystem.File.Exists(path);
+    public bool FileExists(IAssetLinkGetter path) => _fileSystem.File.Exists(Path.Join(_dataDirectory.Path, path.DataRelativePath.Path));
+    public bool FileExistsIfNotNull([NotNullWhen(false)] IAssetLinkGetter? path) => path == null || FileExists(path);
 }


### PR DESCRIPTION
Missing assets analysers were always failing due to:
1. They used the implicit (string)File rather than File.DataRelativePath, which would miss the meshes/textures prefix
2. MissingAssetsAnalyzerUtil searched in the executable's working directory rather than data directory

Test cases were passing as they provide an absolute path in AssetLink.GivenPath, which is returned by (string)AssetLink. In real data, GivenPath is relative to Meshes/Textures.

The issue of test case asset links differing from real data is with Mutagen, I am unsure of how to resolve this.