### PR TITLE
Use usage cache in DialogueAliasAnalyzer, fix false positive/negatives, add test cases

### DIFF
--- a/Mutagen.Bethesda.Analyzers.Skyrim.Tests/ContextualRecords/Quests/DialogueAliasAnalyzerTest.cs
+++ b/Mutagen.Bethesda.Analyzers.Skyrim.Tests/ContextualRecords/Quests/DialogueAliasAnalyzerTest.cs
@@ -1,0 +1,64 @@
+using Mutagen.Bethesda.Analyzers.Skyrim.Record.Quest;
+using Mutagen.Bethesda.Analyzers.Testing.Frameworks;
+using Mutagen.Bethesda.Plugins;
+using Mutagen.Bethesda.Skyrim;
+using Mutagen.Bethesda.Testing.AutoData;
+using Xunit;
+
+namespace Mutagen.Bethesda.Analyzers.Skyrim.Tests.ContextualRecords.Quests;
+
+using Fixture = ContextualRecordTestFixture<DialogueAliasAnalyzer, Quest, IQuestGetter>;
+
+public class DialogueAliasAnalyzerTest
+{
+    // Create a response that uses GetIsAliasRef on an alias that is forced NONE
+    DialogResponses Setup(Fixture fixture, Quest quest, ISkyrimMod mod)
+    {
+        var topic = fixture.Create<DialogTopic>();
+        topic.Quest.SetTo(quest);
+        mod.DialogTopics.Add(topic);
+        var info = fixture.Create<DialogResponses>();
+        topic.Responses.Add(info);
+
+        quest.Aliases.Add(new QuestAlias() { ID = 1, ForcedReference = new FormLinkNullable<IPlacedGetter>() });
+        info.Conditions.Add(new ConditionFloat()
+        {
+            ComparisonValue = 1,
+            Data = new GetIsAliasRefConditionData() { ReferenceAliasIndex = 1 },
+        });
+        return info;
+    }
+
+    // Assigning an additional voice types form list populates voice types for export
+    [Theory, MutagenModAutoData]
+    public void NoVoiceList(Fixture fixture)
+    {
+        fixture.Run(
+            prepForError: (rec, mod) =>
+            {
+                Setup(fixture, rec, mod);
+            },
+            prepForFix: (rec, mod) =>
+            {
+                rec.Aliases[0].VoiceTypes.SetTo(FormKeys.SkyrimSE.Skyrim.FormList.DefaultNPCVoiceTypes);
+            },
+            DialogueAliasAnalyzer.InvalidDialogueAlias);
+    }
+
+    // Assigning a speaker NPC exports the speakers voice type
+    [Theory, MutagenModAutoData]
+    public void ExplicitSpeaker(Fixture fixture)
+    {
+        DialogResponses? response = null;
+        fixture.Run(
+            prepForError: (rec, mod) =>
+            {
+                response = Setup(fixture, rec, mod);
+            },
+            prepForFix: (rec, mod) =>
+            {
+                response!.Speaker.SetTo(FormKeys.SkyrimSE.Skyrim.Npc.DA02Boethiah);
+            },
+            DialogueAliasAnalyzer.InvalidDialogueAlias);
+    }
+}

--- a/Mutagen.Bethesda.Analyzers.Skyrim/Record/Quest/DialogueAliasAnalyzer.cs
+++ b/Mutagen.Bethesda.Analyzers.Skyrim/Record/Quest/DialogueAliasAnalyzer.cs
@@ -1,5 +1,6 @@
 using Mutagen.Bethesda.Analyzers.SDK.Analyzers;
 using Mutagen.Bethesda.Analyzers.SDK.Topics;
+using Mutagen.Bethesda.Plugins.Cache;
 using Mutagen.Bethesda.Skyrim;
 using Noggog;
 
@@ -27,8 +28,11 @@ public class DialogueAliasAnalyzer : IContextualRecordAnalyzer<IQuestGetter>
 
         var referencedDialogue = new Dictionary<IQuestAliasGetter, List<IDialogResponsesGetter>>();
 
-        // TODO: potentially replace with reference cache
-        foreach (var topic in param.LinkCache.PriorityOrder.WinningOverrides<IDialogTopicGetter>())
+        var topics = param.ResolveCache<ILinkUsageCache>()
+            .GetUsagesOf<IDialogTopicGetter>(quest).UsageLinks
+            .Select(t => t.Resolve(param.LinkCache));
+
+        foreach (var topic in topics)
         {
             if (quest.FormKey != topic.Quest.FormKey) continue;
 

--- a/Mutagen.Bethesda.Analyzers.Skyrim/Record/Quest/DialogueAliasAnalyzer.cs
+++ b/Mutagen.Bethesda.Analyzers.Skyrim/Record/Quest/DialogueAliasAnalyzer.cs
@@ -20,6 +20,7 @@ public class DialogueAliasAnalyzer : IContextualRecordAnalyzer<IQuestGetter>
         var quest = param.Record;
         var relevantAliases = quest.Aliases
             .Where(alias => alias.IsForcedNone(quest))
+            .Where(alias => alias.VoiceTypes.IsNull)
             .ToList();
 
         if (relevantAliases.Count == 0) return;
@@ -33,7 +34,7 @@ public class DialogueAliasAnalyzer : IContextualRecordAnalyzer<IQuestGetter>
 
             foreach (var response in topic.Responses)
             {
-                if (response.Speaker.IsNull) continue;
+                if (!response.Speaker.IsNull) continue;
 
                 foreach (var condition in response.Conditions)
                 {


### PR DESCRIPTION
Contrary to the specification in discussion #252, DialogueAliasAnalyzer did not check for an alias with an additional voice type list and only analysed responses that had an explicit speaker rather than skipping them.

Replacing iteration of topics with a usage cache gives an order of magnitude speed increase. Replaces O(TopicsInLoadOrder) loop with O(TopicsInQuest) loop.