### PR TITLE
Enable UnusedSharedDialogue analyser

### DIFF
--- a/Mutagen.Bethesda.Analyzers.Skyrim.Tests/ContextualRecords/Dialog/Responses/SharedDialogueAnalyzerTest.cs
+++ b/Mutagen.Bethesda.Analyzers.Skyrim.Tests/ContextualRecords/Dialog/Responses/SharedDialogueAnalyzerTest.cs
@@ -1,0 +1,66 @@
+using Mutagen.Bethesda.Analyzers.Skyrim.Record.Dialog.Responses;
+using Mutagen.Bethesda.Analyzers.Testing.Frameworks;
+using Mutagen.Bethesda.Plugins;
+using Mutagen.Bethesda.Skyrim;
+using Mutagen.Bethesda.Testing.AutoData;
+using Xunit;
+
+namespace Mutagen.Bethesda.Analyzers.Skyrim.Tests.ContextualRecords.Dialog.Responses;
+
+using Fixture = ContextualRecordTestFixture<SharedDialogueAnalyzer, DialogResponses, IDialogResponsesGetter>;
+
+public class SharedDialogueAnalyzerTest
+{
+    // Add `responses` to a new shared info topic
+    static void CreateSharedTopic(Fixture fixture, ISkyrimMod mod, DialogResponses responses)
+    {
+        var topic = fixture.Create<DialogTopic>();
+        mod.DialogTopics.Add(topic);
+        topic.SubtypeName = "IDAT";
+        topic.Responses.Add(responses);
+    }
+
+    // Create a new response that uses `responses` as its shared response data
+    static void AddResponseUser(Fixture fixture, ISkyrimMod mod, DialogResponses responses)
+    {
+        var topic = fixture.Create<DialogTopic>();
+        mod.DialogTopics.Add(topic);
+        var response = fixture.Create<DialogResponses>();
+        topic.Responses.Add(response);
+        response.ResponseData.SetTo(responses);
+    }
+
+    [Theory, MutagenModAutoData]
+    public void ScriptInSharedDialogue(Fixture fixture)
+    {
+        fixture.Run(
+            prepForError: (rec, mod) =>
+            {
+                CreateSharedTopic(fixture, mod, rec);
+                rec.VirtualMachineAdapter = new() { Scripts = [new() { Name = "TIF__MyFragment" }] };
+
+                // Satisfy UnusedSharedDialogue
+                AddResponseUser(fixture, mod, rec);
+            },
+            prepForFix: (rec, mod) =>
+            {
+                rec.VirtualMachineAdapter = null;
+            },
+            SharedDialogueAnalyzer.ScriptInSharedDialogue);
+    }
+
+    [Theory, MutagenModAutoData]
+    public void UnusedSharedDialogue(Fixture fixture)
+    {
+        fixture.Run(
+            prepForError: (rec, mod) =>
+            {
+                CreateSharedTopic(fixture, mod, rec);
+            },
+            prepForFix: (rec, mod) =>
+            {
+                AddResponseUser(fixture, mod, rec);
+            },
+            SharedDialogueAnalyzer.UnusedSharedDialogue);
+    }
+}

--- a/Mutagen.Bethesda.Analyzers.Skyrim/Record/Dialog/Responses/SharedDialogueAnalyzer.cs
+++ b/Mutagen.Bethesda.Analyzers.Skyrim/Record/Dialog/Responses/SharedDialogueAnalyzer.cs
@@ -1,5 +1,6 @@
-﻿using Mutagen.Bethesda.Analyzers.SDK.Analyzers;
+using Mutagen.Bethesda.Analyzers.SDK.Analyzers;
 using Mutagen.Bethesda.Analyzers.SDK.Topics;
+using Mutagen.Bethesda.Plugins.Cache;
 using Mutagen.Bethesda.Skyrim;
 
 namespace Mutagen.Bethesda.Analyzers.Skyrim.Record.Dialog.Responses;
@@ -34,17 +35,16 @@ public class SharedDialogueAnalyzer : IContextualRecordAnalyzer<IDialogResponses
                 ScriptInSharedDialogue.Format());
         }
 
-        // TODO: add when there is a reference cache - this is too slow
-        // var isNotUsed = param.LinkCache.PriorityOrder
-        //     .SelectMany(x => x.EnumerateMajorRecords<IDialogResponsesGetter>())
-        //     .Where(r => !r.ResponseData.IsNull)
-        //     .All(r => r.ResponseData.FormKey != responses.FormKey);
-        //
-        // if (isNotUsed)
-        // {
-        //     param.AddTopic(
-        //         UnusedSharedDialogue.Format());
-        // }
+        bool isUsed = param.ResolveCache<ILinkUsageCache>()
+            .GetUsagesOf<IDialogResponsesGetter>(responses).UsageLinks
+            .Select(r => r.Resolve(param.LinkCache))
+            .Any(r => r.ResponseData.Equals(responses));
+
+        if (!isUsed)
+        {
+            param.AddTopic(
+                UnusedSharedDialogue.Format());
+        }
     }
 
     public IEnumerable<Func<IDialogResponsesGetter, object?>> FieldsOfInterest()


### PR DESCRIPTION
This was originally commented out over performance concerns. These concerns are resolved by using a link usage cache instead of iterating all response records.