### PR TITLE
 Use usage cache for IsLocationAppliedToInterior and RefTypeSettlementHouseAnalyzer

### DIFF
--- a/Mutagen.Bethesda.Analyzers.Skyrim.Tests/ContextualRecords/Locations/RefTypeSettlementHouseAnalyzerTest.cs
+++ b/Mutagen.Bethesda.Analyzers.Skyrim.Tests/ContextualRecords/Locations/RefTypeSettlementHouseAnalyzerTest.cs
@@ -1,0 +1,35 @@
+using Mutagen.Bethesda.Analyzers.Skyrim.Record.Location;
+using Mutagen.Bethesda.Analyzers.Testing.Frameworks;
+using Mutagen.Bethesda.Skyrim;
+using Mutagen.Bethesda.Testing.AutoData;
+using Xunit;
+
+namespace Mutagen.Bethesda.Analyzers.Skyrim.Tests.ContextualRecords.Locations;
+
+using Fixture = ContextualRecordTestFixture<RefTypeSettlementHouseAnalyzer, Location, ILocationGetter>;
+
+public class RefTypeSettlementHouseAnalyzerTest
+{
+    [Theory, MutagenModAutoData]
+    public void NoHouseContainer(Fixture fixture)
+    {
+        fixture.Run(
+            prepForError: (rec, mod) =>
+            {
+                rec.Keywords = [FormKeys.SkyrimSE.Skyrim.Keyword.LocTypeHouse];
+
+                var cell = fixture.Create<Cell>();
+                cell.Flags |= Cell.Flag.IsInteriorCell;
+                mod.Cells.AddInteriorCell(cell);
+                cell.Location.SetTo(rec);
+            },
+            prepForFix: (rec, mod) =>
+            {
+                rec.LocationRefTypeReferencesAdded =[new()
+                {
+                    LocationRefType = FormKeys.SkyrimSE.Skyrim.LocationReferenceType.HouseContainerRefType
+                }];
+            },
+            RefTypeSettlementHouseAnalyzer.NoHouseContainerRefType);
+    }
+}

--- a/Mutagen.Bethesda.Analyzers.Skyrim/Extensions/LocationExtensions.cs
+++ b/Mutagen.Bethesda.Analyzers.Skyrim/Extensions/LocationExtensions.cs
@@ -1,4 +1,4 @@
-﻿using Mutagen.Bethesda.Plugins;
+using Mutagen.Bethesda.Plugins;
 using Mutagen.Bethesda.Plugins.Cache;
 using Mutagen.Bethesda.Skyrim;
 
@@ -6,19 +6,12 @@ namespace Mutagen.Bethesda.Analyzers.Skyrim.Extensions;
 
 public static class LocationExtensions
 {
-    public static bool IsLocationAppliedToInterior(this ILocationGetter location, ILinkCache linkCache)
+    public static bool IsLocationAppliedToInterior(this ILocationGetter location, ILinkCache linkCache, ILinkUsageCache usageCache)
     {
-        // todo with reference cache, this can be optimized
-        var interiorLocations = new HashSet<FormKey>();
-        foreach (var cell in linkCache.PriorityOrder.WinningOverrides<ICellGetter>())
-        {
-            if (cell.IsInteriorCell() && !cell.Location.FormKey.IsNull)
-            {
-                interiorLocations.Add(cell.Location.FormKey);
-            }
-        }
-
-        return interiorLocations.Contains(location.FormKey);
+        return usageCache.GetUsagesOf<ICellGetter>(location).UsageLinks
+            .Select(c => c.Resolve(linkCache))
+            .Where(c => c.Location.Equals(location))
+            .Any(c => c.IsInteriorCell());
     }
 
     private static readonly HashSet<IFormLinkGetter<IKeywordGetter>> SettlementKeywords =

--- a/Mutagen.Bethesda.Analyzers.Skyrim/Record/Location/RefTypeSettlementHouseAnalyzer.cs
+++ b/Mutagen.Bethesda.Analyzers.Skyrim/Record/Location/RefTypeSettlementHouseAnalyzer.cs
@@ -1,6 +1,7 @@
-﻿using Mutagen.Bethesda.Analyzers.SDK.Analyzers;
+using Mutagen.Bethesda.Analyzers.SDK.Analyzers;
 using Mutagen.Bethesda.Analyzers.SDK.Topics;
 using Mutagen.Bethesda.Plugins;
+using Mutagen.Bethesda.Plugins.Cache;
 using Mutagen.Bethesda.Skyrim;
 
 namespace Mutagen.Bethesda.Analyzers.Skyrim.Record.Location;
@@ -32,7 +33,7 @@ public class RefTypeSettlementHouseAnalyzer : IContextualRecordAnalyzer<ILocatio
 
         if (!location.IsSettlementLocation()) return;
         if (!location.IsSettlementHouseLocationNotPlayerHome()) return;
-        if (!location.IsLocationAppliedToInterior(param.LinkCache)) return;
+        if (!location.IsLocationAppliedToInterior(param.LinkCache, param.ResolveCache<ILinkUsageCache>())) return;
 
         if (location.LocationRefTypesReferences().Any(staticRef => HouseContainerRefTypes.Contains(staticRef.LocationRefType)))
         {


### PR DESCRIPTION
This is an order of magnitude faster than the previous implementation
that iterated all cells for each location. Replace O(CellsInLoadOrder) iteration with O(1) lookup