### PR TITLE
Optimise NoParentLocationAnalyzer and add tests

### DIFF
--- a/Mutagen.Bethesda.Analyzers.Skyrim.Tests/ContextualRecords/Locations/NoParentLocationAnalyzerTest.cs
+++ b/Mutagen.Bethesda.Analyzers.Skyrim.Tests/ContextualRecords/Locations/NoParentLocationAnalyzerTest.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Mutagen.Bethesda.Analyzers.Skyrim.Record.Location;
+using Mutagen.Bethesda.Analyzers.Testing.Frameworks;
+using Mutagen.Bethesda.Skyrim;
+using Mutagen.Bethesda.Testing.AutoData;
+using Xunit;
+
+namespace Mutagen.Bethesda.Analyzers.Skyrim.Tests.ContextualRecords.Locations;
+
+using Fixture = ContextualRecordTestFixture<NoParentLocationAnalyzer, Location, ILocationGetter>;
+
+public class NoParentLocationAnalyzerTest
+{
+    [Theory, MutagenModAutoData]
+    public void NoParent(Fixture fixture)
+    {
+        fixture.Run(
+            prepForError: (rec, mod) =>
+            {
+                rec.ParentLocation.SetToNull();
+            },
+            prepForFix: (rec, mod) =>
+            {
+                rec.ParentLocation.SetTo(FormKeys.SkyrimSE.Skyrim.Location.RiverwoodLocation);
+            },
+            NoParentLocationAnalyzer.NoParentLocation);
+    }
+
+    [Theory, MutagenModAutoData]
+    public void WorldspaceLocation(Fixture fixture)
+    {
+        fixture.Run(
+            prepForError: (rec, mod) =>
+            {
+                rec.ParentLocation.SetToNull();
+            },
+            prepForFix: (rec, mod) =>
+            {
+                var world = fixture.Create<Worldspace>();
+                mod.Worldspaces.Add(world);
+                world.Location.SetTo(rec);
+            },
+            NoParentLocationAnalyzer.NoParentLocation);
+    }
+}

--- a/Mutagen.Bethesda.Analyzers.Skyrim.Tests/ContextualRecords/Locations/NoParentLocationAnalyzerTest.cs
+++ b/Mutagen.Bethesda.Analyzers.Skyrim.Tests/ContextualRecords/Locations/NoParentLocationAnalyzerTest.cs
@@ -1,8 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Mutagen.Bethesda.Analyzers.Skyrim.Record.Location;
 using Mutagen.Bethesda.Analyzers.Testing.Frameworks;
 using Mutagen.Bethesda.Skyrim;

--- a/Mutagen.Bethesda.Analyzers.Skyrim/Record/Location/NoParentLocationAnalyzer.cs
+++ b/Mutagen.Bethesda.Analyzers.Skyrim/Record/Location/NoParentLocationAnalyzer.cs
@@ -1,6 +1,7 @@
-﻿using Mutagen.Bethesda.Analyzers.SDK.Analyzers;
+using Mutagen.Bethesda.Analyzers.SDK.Analyzers;
 using Mutagen.Bethesda.Analyzers.SDK.Topics;
 using Mutagen.Bethesda.Plugins;
+using Mutagen.Bethesda.Plugins.Cache;
 using Mutagen.Bethesda.Skyrim;
 
 namespace Mutagen.Bethesda.Analyzers.Skyrim.Record.Location;
@@ -29,6 +30,11 @@ public class NoParentLocationAnalyzer : IContextualRecordAnalyzer<ILocationGette
     {
         var location = param.Record;
 
+        if (!location.ParentLocation.IsNull)
+        {
+            return;
+        }
+
         // Ignore some well known top level locations
         if (ValidTopLevelLocations.Contains(location))
         {
@@ -36,17 +42,17 @@ public class NoParentLocationAnalyzer : IContextualRecordAnalyzer<ILocationGette
         }
 
         // Ignore locations that are assigned on a worldspace level
-        if (param.LinkCache.PriorityOrder.WinningOverrides<IWorldspaceGetter>()
-            .Select(x => x.Location)
-            .Any(x => x.FormKey == location.FormKey))
+        var isWorldspaceLocation = param.ResolveCache<ILinkUsageCache>()
+            .GetUsagesOf<IWorldspaceGetter>(location).UsageLinks
+            .Select(w => w.Resolve(param.LinkCache))
+            .Any(w => w.Location.Equals(location));
+
+        if (isWorldspaceLocation)
         {
             return;
         }
 
-        if (location.ParentLocation.IsNull)
-        {
-            param.AddTopic(NoParentLocation.Format());
-        }
+        param.AddTopic(NoParentLocation.Format());
     }
 
     public IEnumerable<Func<ILocationGetter, object?>> FieldsOfInterest()


### PR DESCRIPTION
Tweak order of operations to perform expensive checks last and use usage cache for for worldspace locations.