### PR TITLE
Use usage cache for NoMerchantChestLocRefTypeAnalyzerTest

### DIFF
--- a/Mutagen.Bethesda.Analyzers.Skyrim.Tests/ContextualRecords/Cells/Interior/Settlement/NoMerchantChestLocRefTypeAnalyzerTest.cs
+++ b/Mutagen.Bethesda.Analyzers.Skyrim.Tests/ContextualRecords/Cells/Interior/Settlement/NoMerchantChestLocRefTypeAnalyzerTest.cs
@@ -1,0 +1,71 @@
+using Mutagen.Bethesda.Analyzers.Skyrim.Record.Cell.Interior.Settlement;
+using Mutagen.Bethesda.Analyzers.Testing.Frameworks;
+using Mutagen.Bethesda.Skyrim;
+using Mutagen.Bethesda.Testing.AutoData;
+using Xunit;
+
+namespace Mutagen.Bethesda.Analyzers.Skyrim.Tests.ContextualRecords.Cells.Interior.Settlement;
+
+using Fixture = ContextualRecordTestFixture<NoMerchantChestLocRefTypeAnalyzer, Cell, ICellGetter>;
+
+public class NoMerchantChestLocRefTypeAnalyzerTest
+{
+    // Configure a cell as a settlement interior and add a container
+    PlacedObject Setup(Fixture fixture, ISkyrimMod mod, Cell cell)
+    {
+        var location = fixture.Create<Location>();
+        mod.Locations.Add(location);
+        location.Keywords = [FormKeys.SkyrimSE.Skyrim.Keyword.LocTypeHouse];
+        cell.Location.SetTo(location);
+
+        cell.Flags |= Cell.Flag.IsInteriorCell;
+        mod.Cells.AddInteriorCell(cell);
+
+        var placed = fixture.Create<PlacedObject>();
+        cell.Persistent.Add(placed);
+        return placed;
+    }
+
+    // Add a vendor faction that uses the provided object as its merchant container
+    void AddMerchantFaction(Fixture fixture, ISkyrimMod mod, PlacedObject chest)
+    {
+        var faction = fixture.Create<Faction>();
+        mod.Factions.Add(faction);
+        faction.Flags |= Faction.FactionFlag.Vendor;
+        faction.MerchantContainer.SetTo(chest);
+    }
+
+    [Theory, MutagenModAutoData]
+    public void NoRefType(Fixture fixture)
+    {
+        PlacedObject? chest = null;
+        fixture.Run(
+            prepForError: (rec, mod) =>
+            {
+                chest = Setup(fixture, mod, rec);
+                AddMerchantFaction(fixture, mod, chest);
+            },
+            prepForFix: (rec, mod) =>
+            {
+                chest!.LocationRefTypes = [FormKeys.SkyrimSE.Skyrim.LocationReferenceType.MerchantContainerRefType];
+            },
+            NoMerchantChestLocRefTypeAnalyzer.NoMerchantChestLocRefType);
+    }
+
+    [Theory, MutagenModAutoData]
+    public void NotMerchantChest(Fixture fixture)
+    {
+        PlacedObject? chest = null;
+        fixture.Run(
+            prepForError: (rec, mod) =>
+            {
+                chest = Setup(fixture, mod, rec);
+                chest.LocationRefTypes = [FormKeys.SkyrimSE.Skyrim.LocationReferenceType.MerchantContainerRefType];
+            },
+            prepForFix: (rec, mod) =>
+            {
+                AddMerchantFaction(fixture, mod, chest!);
+            },
+            NoMerchantChestLocRefTypeAnalyzer.InvalidMerchantChestLocRefType);
+    }
+}

--- a/Mutagen.Bethesda.Analyzers.Skyrim/Record/Cell/Interior/Settlement/NoMerchantChestLocRefTypeAnalyzer.cs
+++ b/Mutagen.Bethesda.Analyzers.Skyrim/Record/Cell/Interior/Settlement/NoMerchantChestLocRefTypeAnalyzer.cs
@@ -1,5 +1,6 @@
-﻿using Mutagen.Bethesda.Analyzers.SDK.Analyzers;
+using Mutagen.Bethesda.Analyzers.SDK.Analyzers;
 using Mutagen.Bethesda.Analyzers.SDK.Topics;
+using Mutagen.Bethesda.Plugins.Cache;
 using Mutagen.Bethesda.Skyrim;
 
 namespace Mutagen.Bethesda.Analyzers.Skyrim.Record.Cell.Interior.Settlement;
@@ -24,19 +25,17 @@ public class NoMerchantChestLocRefTypeAnalyzer : IContextualRecordAnalyzer<ICell
     {
         var cell = param.Record;
 
-        var merchantChests = param.LinkCache.PriorityOrder.WinningOverrides<IFactionGetter>()
-            .Where(faction => faction.Flags.HasFlag(Bethesda.Skyrim.Faction.FactionFlag.Vendor))
-            .Select(faction => faction.MerchantContainer.FormKey)
-            .ToHashSet();
-
         // Skip non-settlement cells
         if (!cell.IsSettlementCell(param.LinkCache)) return;
 
         foreach (var placedObject in cell.GetAllPlaced(param.LinkCache).OfType<IPlacedObjectGetter>())
         {
             if (placedObject.IsDeleted) continue;
-            // todo: replace with reference cache
-            var isMerchantChest = merchantChests.Contains(placedObject.FormKey);
+
+            var isMerchantChest = param.ResolveCache<ILinkUsageCache>()
+                .GetUsagesOf<IFactionGetter>(placedObject).UsageLinks
+                .Select(f => f.Resolve(param.LinkCache))
+                .Any(f => f.MerchantContainer.Equals(placedObject));
             var hasLocRefType = placedObject.HasLocationRefType(FormKeys.SkyrimSE.Skyrim.LocationReferenceType.MerchantContainerRefType);
 
             if (isMerchantChest && !hasLocRefType)


### PR DESCRIPTION
This is an order of magnitude faster than before. Replaces O(FactionsInLoadOrder) iteration with O(1) lookup