### PR TITLE
Add empty fragment and duplicate fragment analysers

### DIFF
--- a/Mutagen.Bethesda.Analyzers.Skyrim.Tests/IsolatedRecords/Dialog/Responses/FragmentAnalyzerResponsesTest.cs
+++ b/Mutagen.Bethesda.Analyzers.Skyrim.Tests/IsolatedRecords/Dialog/Responses/FragmentAnalyzerResponsesTest.cs
@@ -1,0 +1,67 @@
+using Mutagen.Bethesda.Analyzers.Skyrim.Record.Dialog.Responses;
+using Mutagen.Bethesda.Analyzers.Testing.Frameworks;
+using Mutagen.Bethesda.Skyrim;
+using Mutagen.Bethesda.Testing.AutoData;
+using Xunit;
+
+namespace Mutagen.Bethesda.Analyzers.Skyrim.Tests.IsolatedRecords.Dialog.Responses;
+
+using Fixture = IsolatedRecordTestFixture<FragmentAnalyzerResponses, DialogResponses, IDialogResponsesGetter>;
+
+public class FragmentAnalyzerResponsesTest
+{
+    [Theory, MutagenModAutoData]
+    public void DuplicateFragment(Fixture fixture)
+    {
+        fixture.Run(
+            prepForError: rec =>
+            {
+                rec.VirtualMachineAdapter = new()
+                {
+                    ScriptFragments = new()
+                    {
+                        OnBegin = new() { FragmentName = "Fragment_0" },
+                        OnEnd = new() { FragmentName = "fragment_0" }
+                    }
+                };
+            },
+            prepForFix: rec =>
+            {
+                rec.VirtualMachineAdapter!.ScriptFragments!.OnEnd!.FragmentName = "Fragment_1";
+            },
+            FragmentAnalyzerResponses.DuplicateFragment);
+    }
+
+    [Theory, MutagenModAutoData]
+    public void EmptyFragment(Fixture fixture)
+    {
+        fixture.Run(
+            prepForError: rec =>
+            {
+                rec.VirtualMachineAdapter = new();
+            },
+            prepForFix: rec =>
+            {
+                rec.VirtualMachineAdapter = null;
+            },
+            FragmentAnalyzerResponses.EmptyFragment);
+    }
+
+    [Theory, MutagenModAutoData]
+    public void EmptyFragmentAdd(Fixture fixture)
+    {
+        fixture.Run(
+            prepForError: rec =>
+            {
+                rec.VirtualMachineAdapter = new();
+            },
+            prepForFix: rec =>
+            {
+                rec.VirtualMachineAdapter!.ScriptFragments = new()
+                {
+                    OnBegin = new() { FragmentName = "Fragment_0" }
+                };
+            },
+            FragmentAnalyzerResponses.EmptyFragment);
+    }
+}

--- a/Mutagen.Bethesda.Analyzers.Skyrim.Tests/IsolatedRecords/Perks/FragmentAnalyzerPerkTest.cs
+++ b/Mutagen.Bethesda.Analyzers.Skyrim.Tests/IsolatedRecords/Perks/FragmentAnalyzerPerkTest.cs
@@ -1,6 +1,4 @@
-using Mutagen.Bethesda.Analyzers.Skyrim.Record.Dialog.Responses;
 using Mutagen.Bethesda.Analyzers.Skyrim.Record.Perk;
-using Mutagen.Bethesda.Analyzers.Skyrim.Record.Quest;
 using Mutagen.Bethesda.Analyzers.Testing.Frameworks;
 using Mutagen.Bethesda.Skyrim;
 using Mutagen.Bethesda.Testing.AutoData;
@@ -34,7 +32,7 @@ public class FragmentAnalyzerPerkTest
             {
                 rec.VirtualMachineAdapter!.ScriptFragments!.Fragments[1].FragmentName = "Fragment_1";
             },
-            FragmentAnalyzerQuest.DuplicateFragment);
+            FragmentAnalyzerPerk.DuplicateFragment);
     }
 
     [Theory, MutagenModAutoData]
@@ -49,7 +47,7 @@ public class FragmentAnalyzerPerkTest
             {
                 rec.VirtualMachineAdapter = null;
             },
-            FragmentAnalyzerResponses.EmptyFragment);
+            FragmentAnalyzerPerk.EmptyFragment);
     }
 
     [Theory, MutagenModAutoData]
@@ -67,6 +65,6 @@ public class FragmentAnalyzerPerkTest
                     Fragments = [new() { FragmentName = "Fragment_0" }]
                 };
             },
-            FragmentAnalyzerResponses.EmptyFragment);
+            FragmentAnalyzerPerk.EmptyFragment);
     }
 }

--- a/Mutagen.Bethesda.Analyzers.Skyrim.Tests/IsolatedRecords/Perks/FragmentAnalyzerPerkTest.cs
+++ b/Mutagen.Bethesda.Analyzers.Skyrim.Tests/IsolatedRecords/Perks/FragmentAnalyzerPerkTest.cs
@@ -1,0 +1,72 @@
+using Mutagen.Bethesda.Analyzers.Skyrim.Record.Dialog.Responses;
+using Mutagen.Bethesda.Analyzers.Skyrim.Record.Perk;
+using Mutagen.Bethesda.Analyzers.Skyrim.Record.Quest;
+using Mutagen.Bethesda.Analyzers.Testing.Frameworks;
+using Mutagen.Bethesda.Skyrim;
+using Mutagen.Bethesda.Testing.AutoData;
+using Xunit;
+
+namespace Mutagen.Bethesda.Analyzers.Skyrim.Tests.IsolatedRecords.Perks;
+
+using Fixture = IsolatedRecordTestFixture<FragmentAnalyzerPerk, Perk, IPerkGetter>;
+
+public class FragmentAnalyzerPerkTest
+{
+    [Theory, MutagenModAutoData]
+    public void DuplicateFragment(Fixture fixture)
+    {
+        fixture.Run(
+            prepForError: rec =>
+            {
+                rec.VirtualMachineAdapter = new()
+                {
+                    ScriptFragments = new()
+                    {
+                        Fragments =
+                        [
+                            new() { FragmentName = "Fragment_0" },
+                            new() { FragmentName = "fragment_0" }
+                        ]
+                    }
+                };
+            },
+            prepForFix: rec =>
+            {
+                rec.VirtualMachineAdapter!.ScriptFragments!.Fragments[1].FragmentName = "Fragment_1";
+            },
+            FragmentAnalyzerQuest.DuplicateFragment);
+    }
+
+    [Theory, MutagenModAutoData]
+    public void EmptyFragment(Fixture fixture)
+    {
+        fixture.Run(
+            prepForError: rec =>
+            {
+                rec.VirtualMachineAdapter = new();
+            },
+            prepForFix: rec =>
+            {
+                rec.VirtualMachineAdapter = null;
+            },
+            FragmentAnalyzerResponses.EmptyFragment);
+    }
+
+    [Theory, MutagenModAutoData]
+    public void EmptyFragmentAdd(Fixture fixture)
+    {
+        fixture.Run(
+            prepForError: rec =>
+            {
+                rec.VirtualMachineAdapter = new();
+            },
+            prepForFix: rec =>
+            {
+                rec.VirtualMachineAdapter!.ScriptFragments = new()
+                {
+                    Fragments = [new() { FragmentName = "Fragment_0" }]
+                };
+            },
+            FragmentAnalyzerResponses.EmptyFragment);
+    }
+}

--- a/Mutagen.Bethesda.Analyzers.Skyrim.Tests/IsolatedRecords/Quests/FragmentAnalyzerQuestTest.cs
+++ b/Mutagen.Bethesda.Analyzers.Skyrim.Tests/IsolatedRecords/Quests/FragmentAnalyzerQuestTest.cs
@@ -1,7 +1,5 @@
-using Mutagen.Bethesda.Analyzers.Skyrim.Extensions;
 using Mutagen.Bethesda.Analyzers.Skyrim.Record.Quest;
 using Mutagen.Bethesda.Analyzers.Testing.Frameworks;
-using Mutagen.Bethesda.Plugins;
 using Mutagen.Bethesda.Skyrim;
 using Mutagen.Bethesda.Testing.AutoData;
 using Noggog;

--- a/Mutagen.Bethesda.Analyzers.Skyrim.Tests/IsolatedRecords/Quests/FragmentAnalyzerQuestTest.cs
+++ b/Mutagen.Bethesda.Analyzers.Skyrim.Tests/IsolatedRecords/Quests/FragmentAnalyzerQuestTest.cs
@@ -1,0 +1,87 @@
+using Mutagen.Bethesda.Analyzers.Skyrim.Extensions;
+using Mutagen.Bethesda.Analyzers.Skyrim.Record.Quest;
+using Mutagen.Bethesda.Analyzers.Testing.Frameworks;
+using Mutagen.Bethesda.Plugins;
+using Mutagen.Bethesda.Skyrim;
+using Mutagen.Bethesda.Testing.AutoData;
+using Noggog;
+using Noggog.Testing.Extensions;
+using Xunit;
+
+namespace Mutagen.Bethesda.Analyzers.Skyrim.Tests.IsolatedRecords.Quests;
+
+using Fixture = IsolatedRecordTestFixture<FragmentAnalyzerQuest, Quest, IQuestGetter>;
+
+public class FragmentAnalyzerQuestTest
+{
+    [Theory, MutagenModAutoData]
+    public void DuplicateFragment(Fixture fixture)
+    {
+        fixture.Run(
+            prepForError: rec =>
+            {
+                rec.VirtualMachineAdapter = new();
+                rec.VirtualMachineAdapter.Fragments.Add(new()
+                {
+                    FragmentName = "Fragment_0",
+                });
+                rec.VirtualMachineAdapter.Fragments.Add(new()
+                {
+                    FragmentName = "Fragment_0",
+                });
+            },
+            prepForFix: rec =>
+            {
+                rec.VirtualMachineAdapter!.Fragments[1].FragmentName = "Fragment_1";
+            },
+            FragmentAnalyzerQuest.DuplicateFragment);
+    }
+
+    void AddEmptyFragmentScript(Quest quest)
+    {
+        quest.VirtualMachineAdapter = new();
+        quest.VirtualMachineAdapter.Scripts.Add(new()
+        {
+            Name = "QF_MyQuest"
+        });
+        quest.VirtualMachineAdapter.Scripts.Add(new()
+        {
+            Name = "MyQuestScript"
+        });
+    }
+
+    [Theory, MutagenModAutoData]
+    public void EmptyFragmentRemove(Fixture fixture)
+    {
+        fixture.Run(
+            prepForError: AddEmptyFragmentScript,
+            prepForFix: rec =>
+            {
+                rec.VirtualMachineAdapter!.Scripts.RemoveAt(0);
+            },
+            FragmentAnalyzerQuest.EmptyFragment);
+    }
+
+    [Theory, MutagenModAutoData]
+    public void EmptyFragmentAddEntry(Fixture fixture)
+    {
+        fixture.Run(
+            prepForError: AddEmptyFragmentScript,
+            prepForFix: rec =>
+            {
+                rec.VirtualMachineAdapter!.Fragments.Add(new() { FragmentName = "Fragment_0" });
+            },
+            FragmentAnalyzerQuest.EmptyFragment);
+    }
+
+    [Theory]
+    [InlineData("QF_MyQuest_1234ABCD", "QF_MyQuest_1234ABCD")]
+    [InlineData("PFX_QF_MyQuest_1234ABCD", "PFX_QF_MyQuest_1234ABCD")]
+    [InlineData("NotAFragment", null)]
+    public void GetFragmentName(string name, string? expected)
+    {
+        var entry = new ScriptEntry() { Name = name };
+        FragmentAnalyzerQuest.GetFragmentScriptName(entry.AsEnumerable())
+            .ShouldEqual(expected);
+    }
+}

--- a/Mutagen.Bethesda.Analyzers.Skyrim.Tests/IsolatedRecords/Scenes/FragmentAnalyzerSceneTest.cs
+++ b/Mutagen.Bethesda.Analyzers.Skyrim.Tests/IsolatedRecords/Scenes/FragmentAnalyzerSceneTest.cs
@@ -1,0 +1,94 @@
+using Mutagen.Bethesda.Analyzers.Skyrim.Record.Dialog.Responses;
+using Mutagen.Bethesda.Analyzers.Skyrim.Record.Scene;
+using Mutagen.Bethesda.Analyzers.Testing.Frameworks;
+using Mutagen.Bethesda.Skyrim;
+using Mutagen.Bethesda.Testing.AutoData;
+using Xunit;
+
+namespace Mutagen.Bethesda.Analyzers.Skyrim.Tests.IsolatedRecords.Scenes;
+
+using Fixture = IsolatedRecordTestFixture<FragmentAnalyzerScene, Scene, ISceneGetter>;
+
+public class FragmentAnalyzerSceneTest
+{
+    [Theory, MutagenModAutoData]
+    public void DuplicateFragment(Fixture fixture)
+    {
+        fixture.Run(
+            prepForError: rec =>
+            {
+                rec.VirtualMachineAdapter = new()
+                {
+                    ScriptFragments = new()
+                    {
+                        PhaseFragments =
+                        [
+                            new() { FragmentName = "Fragment_0" },
+                            new() { FragmentName = "fragment_0" }
+                        ]
+                    }
+                };
+            },
+            prepForFix: rec =>
+            {
+                rec.VirtualMachineAdapter!.ScriptFragments!.PhaseFragments[1].FragmentName = "Fragment_1";
+            },
+            FragmentAnalyzerScene.DuplicateFragment);
+    }
+
+    [Theory, MutagenModAutoData]
+    public void DuplicateFragmentOnBeginEnd(Fixture fixture)
+    {
+        fixture.Run(
+            prepForError: rec =>
+            {
+                rec.VirtualMachineAdapter = new()
+                {
+                    ScriptFragments = new()
+                    {
+                        PhaseFragments = [new() { FragmentName = "Fragment_0" }],
+                        OnBegin = new() { FragmentName = "fragment_0" },
+                        OnEnd = new() { FragmentName = "FRAGMENT_0" },
+                    },
+                };
+            },
+            prepForFix: rec =>
+            {
+                rec.VirtualMachineAdapter!.ScriptFragments!.PhaseFragments[1].FragmentName = "Fragment_1";
+            },
+            FragmentAnalyzerScene.DuplicateFragment);
+    }
+
+    [Theory, MutagenModAutoData]
+    public void EmptyFragment(Fixture fixture)
+    {
+        fixture.Run(
+            prepForError: rec =>
+            {
+                rec.VirtualMachineAdapter = new();
+            },
+            prepForFix: rec =>
+            {
+                rec.VirtualMachineAdapter = null;
+            },
+            FragmentAnalyzerResponses.EmptyFragment);
+    }
+
+    [Theory, MutagenModAutoData]
+    public void EmptyFragmentAdd(Fixture fixture)
+    {
+        fixture.Run(
+            prepForError: rec =>
+            {
+                rec.VirtualMachineAdapter = new();
+            },
+            prepForFix: rec =>
+            {
+                rec.VirtualMachineAdapter!.ScriptFragments = new()
+                {
+                    OnBegin = new() { FragmentName = "Fragment_0" }
+                };
+            },
+            FragmentAnalyzerResponses.EmptyFragment);
+    }
+}

--- a/Mutagen.Bethesda.Analyzers.Skyrim.Tests/IsolatedRecords/Scenes/FragmentAnalyzerSceneTest.cs
+++ b/Mutagen.Bethesda.Analyzers.Skyrim.Tests/IsolatedRecords/Scenes/FragmentAnalyzerSceneTest.cs
@@ -1,4 +1,3 @@
-using Mutagen.Bethesda.Analyzers.Skyrim.Record.Dialog.Responses;
 using Mutagen.Bethesda.Analyzers.Skyrim.Record.Scene;
 using Mutagen.Bethesda.Analyzers.Testing.Frameworks;
 using Mutagen.Bethesda.Skyrim;
@@ -72,7 +71,7 @@ public class FragmentAnalyzerSceneTest
             {
                 rec.VirtualMachineAdapter = null;
             },
-            FragmentAnalyzerResponses.EmptyFragment);
+            FragmentAnalyzerScene.EmptyFragment);
     }
 
     [Theory, MutagenModAutoData]
@@ -90,6 +89,6 @@ public class FragmentAnalyzerSceneTest
                     OnBegin = new() { FragmentName = "Fragment_0" }
                 };
             },
-            FragmentAnalyzerResponses.EmptyFragment);
+            FragmentAnalyzerScene.EmptyFragment);
     }
 }

--- a/Mutagen.Bethesda.Analyzers.Skyrim.Tests/IsolatedRecords/Scenes/FragmentAnalyzerSceneTest.cs
+++ b/Mutagen.Bethesda.Analyzers.Skyrim.Tests/IsolatedRecords/Scenes/FragmentAnalyzerSceneTest.cs
@@ -54,7 +54,8 @@ public class FragmentAnalyzerSceneTest
             },
             prepForFix: rec =>
             {
-                rec.VirtualMachineAdapter!.ScriptFragments!.PhaseFragments[1].FragmentName = "Fragment_1";
+                rec.VirtualMachineAdapter!.ScriptFragments!.OnBegin!.FragmentName = "Fragment_1";
+                rec.VirtualMachineAdapter!.ScriptFragments!.OnEnd!.FragmentName = "Fragment_2";
             },
             FragmentAnalyzerScene.DuplicateFragment);
     }

--- a/Mutagen.Bethesda.Analyzers.Skyrim/Record/Dialog/Responses/FragmentAnalyzerResponses.cs
+++ b/Mutagen.Bethesda.Analyzers.Skyrim/Record/Dialog/Responses/FragmentAnalyzerResponses.cs
@@ -1,0 +1,47 @@
+using Mutagen.Bethesda.Analyzers.SDK.Analyzers;
+using Mutagen.Bethesda.Analyzers.SDK.Topics;
+using Mutagen.Bethesda.Analyzers.Skyrim.Util;
+using Mutagen.Bethesda.Skyrim;
+
+namespace Mutagen.Bethesda.Analyzers.Skyrim.Record.Dialog.Responses;
+
+public class FragmentAnalyzerResponses : IIsolatedRecordAnalyzer<IDialogResponsesGetter>
+{
+    public static readonly TopicDefinition<string> DuplicateFragment = MutagenTopicBuilder.DevelopmentTopic(
+            "Duplicate fragment",
+            Severity.Error)
+        .WithFormatting<string>("Fragment function {0} is used multiple times");
+
+    public static readonly TopicDefinition EmptyFragment = MutagenTopicBuilder.DevelopmentTopic(
+            "Empty fragment script",
+            Severity.Suggestion)
+        .WithoutFormatting("Responses has script attached, but no fragments");
+
+    public IEnumerable<TopicDefinition> Topics => [DuplicateFragment, EmptyFragment];
+
+    public void AnalyzeRecord(IsolatedRecordAnalyzerParams<IDialogResponsesGetter> param)
+    {
+        var vmad = param.Record.VirtualMachineAdapter;
+        if (vmad == null)
+            return;
+
+        if (vmad.ScriptFragments == null)
+        {
+            param.AddTopic(EmptyFragment.Format());
+        }
+        else
+        {
+            FragmentAnalyzerUtil.CheckDuplicateFragments(
+                param,
+                DuplicateFragment,
+                [vmad.ScriptFragments.OnBegin, vmad.ScriptFragments.OnEnd],
+                f => f.FragmentName);
+        }
+
+    }
+
+    public IEnumerable<Func<IDialogResponsesGetter, object?>> FieldsOfInterest()
+    {
+        yield return x => x.VirtualMachineAdapter;
+    }
+}

--- a/Mutagen.Bethesda.Analyzers.Skyrim/Record/Dialog/Responses/FragmentAnalyzerResponses.cs
+++ b/Mutagen.Bethesda.Analyzers.Skyrim/Record/Dialog/Responses/FragmentAnalyzerResponses.cs
@@ -8,14 +8,14 @@ namespace Mutagen.Bethesda.Analyzers.Skyrim.Record.Dialog.Responses;
 public class FragmentAnalyzerResponses : IIsolatedRecordAnalyzer<IDialogResponsesGetter>
 {
     public static readonly TopicDefinition<string> DuplicateFragment = MutagenTopicBuilder.DevelopmentTopic(
-            "Duplicate fragment",
+            "Duplicate fragment dialog responses",
             Severity.Error)
         .WithFormatting<string>("Fragment function {0} is used multiple times");
 
     public static readonly TopicDefinition EmptyFragment = MutagenTopicBuilder.DevelopmentTopic(
-            "Empty fragment script",
+            "Empty fragment dialog responses",
             Severity.Suggestion)
-        .WithoutFormatting("Responses has script attached, but no fragments");
+        .WithoutFormatting("Dialog responses has script attached, but no fragments");
 
     public IEnumerable<TopicDefinition> Topics => [DuplicateFragment, EmptyFragment];
 
@@ -34,8 +34,7 @@ public class FragmentAnalyzerResponses : IIsolatedRecordAnalyzer<IDialogResponse
             FragmentAnalyzerUtil.CheckDuplicateFragments(
                 param,
                 DuplicateFragment,
-                [vmad.ScriptFragments.OnBegin, vmad.ScriptFragments.OnEnd],
-                f => f.FragmentName);
+                [vmad.ScriptFragments.OnBegin?.FragmentName, vmad.ScriptFragments.OnEnd?.FragmentName]);
         }
 
     }

--- a/Mutagen.Bethesda.Analyzers.Skyrim/Record/Dialog/Responses/FragmentAnalyzerResponses.cs
+++ b/Mutagen.Bethesda.Analyzers.Skyrim/Record/Dialog/Responses/FragmentAnalyzerResponses.cs
@@ -14,7 +14,7 @@ public class FragmentAnalyzerResponses : IIsolatedRecordAnalyzer<IDialogResponse
         .WithFormatting<string>("Fragment function {0} is used multiple times");
 
     public static readonly TopicDefinition EmptyFragment = MutagenTopicBuilder.FromDiscussion(
-            587,
+            593,
             "Empty dialog fragment script",
             Severity.Suggestion)
         .WithoutFormatting("Dialog responses has script attached, but no fragments");

--- a/Mutagen.Bethesda.Analyzers.Skyrim/Record/Dialog/Responses/FragmentAnalyzerResponses.cs
+++ b/Mutagen.Bethesda.Analyzers.Skyrim/Record/Dialog/Responses/FragmentAnalyzerResponses.cs
@@ -7,13 +7,15 @@ namespace Mutagen.Bethesda.Analyzers.Skyrim.Record.Dialog.Responses;
 
 public class FragmentAnalyzerResponses : IIsolatedRecordAnalyzer<IDialogResponsesGetter>
 {
-    public static readonly TopicDefinition<string> DuplicateFragment = MutagenTopicBuilder.DevelopmentTopic(
-            "Duplicate fragment dialog responses",
+    public static readonly TopicDefinition<string> DuplicateFragment = MutagenTopicBuilder.FromDiscussion(
+            586,
+            "Duplicate dialog fragment name",
             Severity.Error)
         .WithFormatting<string>("Fragment function {0} is used multiple times");
 
-    public static readonly TopicDefinition EmptyFragment = MutagenTopicBuilder.DevelopmentTopic(
-            "Empty fragment dialog responses",
+    public static readonly TopicDefinition EmptyFragment = MutagenTopicBuilder.FromDiscussion(
+            587,
+            "Empty dialog fragment script",
             Severity.Suggestion)
         .WithoutFormatting("Dialog responses has script attached, but no fragments");
 

--- a/Mutagen.Bethesda.Analyzers.Skyrim/Record/Package/FragmentAnalyzerPackage.cs
+++ b/Mutagen.Bethesda.Analyzers.Skyrim/Record/Package/FragmentAnalyzerPackage.cs
@@ -8,12 +8,12 @@ namespace Mutagen.Bethesda.Analyzers.Skyrim.Record.Package;
 public class FragmentAnalyzerPackage : IIsolatedRecordAnalyzer<IPackageGetter>
 {
     public static readonly TopicDefinition<string> DuplicateFragment = MutagenTopicBuilder.DevelopmentTopic(
-            "Duplicate fragment",
+            "Duplicate fragment package",
             Severity.Error)
         .WithFormatting<string>("Fragment function {0} is used multiple times");
 
     public static readonly TopicDefinition EmptyFragment = MutagenTopicBuilder.DevelopmentTopic(
-            "Empty fragment script",
+            "Empty fragment package",
             Severity.Suggestion)
         .WithoutFormatting("Package has script attached, but no fragments");
 
@@ -34,8 +34,7 @@ public class FragmentAnalyzerPackage : IIsolatedRecordAnalyzer<IPackageGetter>
             FragmentAnalyzerUtil.CheckDuplicateFragments(
                 param,
                 DuplicateFragment,
-                [vmad.ScriptFragments.OnBegin, vmad.ScriptFragments.OnChange, vmad.ScriptFragments.OnEnd],
-                f => f.FragmentName);
+                [vmad.ScriptFragments.OnBegin?.FragmentName, vmad.ScriptFragments.OnChange?.FragmentName, vmad.ScriptFragments.OnEnd?.FragmentName]);
         }
     }
 

--- a/Mutagen.Bethesda.Analyzers.Skyrim/Record/Package/FragmentAnalyzerPackage.cs
+++ b/Mutagen.Bethesda.Analyzers.Skyrim/Record/Package/FragmentAnalyzerPackage.cs
@@ -7,13 +7,15 @@ namespace Mutagen.Bethesda.Analyzers.Skyrim.Record.Package;
 
 public class FragmentAnalyzerPackage : IIsolatedRecordAnalyzer<IPackageGetter>
 {
-    public static readonly TopicDefinition<string> DuplicateFragment = MutagenTopicBuilder.DevelopmentTopic(
-            "Duplicate fragment package",
+    public static readonly TopicDefinition<string> DuplicateFragment = MutagenTopicBuilder.FromDiscussion(
+            587,
+            "Duplicate package fragment name",
             Severity.Error)
         .WithFormatting<string>("Fragment function {0} is used multiple times");
 
-    public static readonly TopicDefinition EmptyFragment = MutagenTopicBuilder.DevelopmentTopic(
-            "Empty fragment package",
+    public static readonly TopicDefinition EmptyFragment = MutagenTopicBuilder.FromDiscussion(
+            588,
+            "Empty package fragment script",
             Severity.Suggestion)
         .WithoutFormatting("Package has script attached, but no fragments");
 

--- a/Mutagen.Bethesda.Analyzers.Skyrim/Record/Package/FragmentAnalyzerPackage.cs
+++ b/Mutagen.Bethesda.Analyzers.Skyrim/Record/Package/FragmentAnalyzerPackage.cs
@@ -1,0 +1,46 @@
+using Mutagen.Bethesda.Analyzers.SDK.Analyzers;
+using Mutagen.Bethesda.Analyzers.SDK.Topics;
+using Mutagen.Bethesda.Analyzers.Skyrim.Util;
+using Mutagen.Bethesda.Skyrim;
+
+namespace Mutagen.Bethesda.Analyzers.Skyrim.Record.Package;
+
+public class FragmentAnalyzerPackage : IIsolatedRecordAnalyzer<IPackageGetter>
+{
+    public static readonly TopicDefinition<string> DuplicateFragment = MutagenTopicBuilder.DevelopmentTopic(
+            "Duplicate fragment",
+            Severity.Error)
+        .WithFormatting<string>("Fragment function {0} is used multiple times");
+
+    public static readonly TopicDefinition EmptyFragment = MutagenTopicBuilder.DevelopmentTopic(
+            "Empty fragment script",
+            Severity.Suggestion)
+        .WithoutFormatting("Package has script attached, but no fragments");
+
+    public IEnumerable<TopicDefinition> Topics => [DuplicateFragment, EmptyFragment];
+
+    public void AnalyzeRecord(IsolatedRecordAnalyzerParams<IPackageGetter> param)
+    {
+        var vmad = param.Record.VirtualMachineAdapter;
+        if (vmad == null)
+            return;
+
+        if (vmad.ScriptFragments == null)
+        {
+            param.AddTopic(EmptyFragment.Format());
+        }
+        else
+        {
+            FragmentAnalyzerUtil.CheckDuplicateFragments(
+                param,
+                DuplicateFragment,
+                [vmad.ScriptFragments.OnBegin, vmad.ScriptFragments.OnChange, vmad.ScriptFragments.OnEnd],
+                f => f.FragmentName);
+        }
+    }
+
+    public IEnumerable<Func<IPackageGetter, object?>> FieldsOfInterest()
+    {
+        yield return x => x.VirtualMachineAdapter;
+    }
+}

--- a/Mutagen.Bethesda.Analyzers.Skyrim/Record/Perk/FragmentAnalyzerPerk.cs
+++ b/Mutagen.Bethesda.Analyzers.Skyrim/Record/Perk/FragmentAnalyzerPerk.cs
@@ -1,0 +1,46 @@
+using Mutagen.Bethesda.Analyzers.SDK.Analyzers;
+using Mutagen.Bethesda.Analyzers.SDK.Topics;
+using Mutagen.Bethesda.Analyzers.Skyrim.Util;
+using Mutagen.Bethesda.Skyrim;
+
+namespace Mutagen.Bethesda.Analyzers.Skyrim.Record.Perk;
+
+public class FragmentAnalyzerPerk : IIsolatedRecordAnalyzer<IPerkGetter>
+{
+    public static readonly TopicDefinition<string> DuplicateFragment = MutagenTopicBuilder.DevelopmentTopic(
+            "Duplicate fragment",
+            Severity.Error)
+        .WithFormatting<string>("Fragment function {0} is used multiple times");
+
+    public static readonly TopicDefinition EmptyFragment = MutagenTopicBuilder.DevelopmentTopic(
+            "Empty fragment script",
+            Severity.Suggestion)
+        .WithoutFormatting("Responses has script attached, but no fragments");
+
+    public IEnumerable<TopicDefinition> Topics => [DuplicateFragment, EmptyFragment];
+
+    public void AnalyzeRecord(IsolatedRecordAnalyzerParams<IPerkGetter> param)
+    {
+        var vmad = param.Record.VirtualMachineAdapter;
+        if (vmad == null)
+            return;
+
+        if (vmad.ScriptFragments == null)
+        {
+            param.AddTopic(EmptyFragment.Format());
+        }
+        else
+        {
+            FragmentAnalyzerUtil.CheckDuplicateFragments(
+                param,
+                DuplicateFragment,
+                vmad.ScriptFragments.Fragments,
+                f => f.FragmentName);
+        }
+    }
+
+    public IEnumerable<Func<IPerkGetter, object?>> FieldsOfInterest()
+    {
+        yield return x => x.VirtualMachineAdapter;
+    }
+}

--- a/Mutagen.Bethesda.Analyzers.Skyrim/Record/Perk/FragmentAnalyzerPerk.cs
+++ b/Mutagen.Bethesda.Analyzers.Skyrim/Record/Perk/FragmentAnalyzerPerk.cs
@@ -8,14 +8,14 @@ namespace Mutagen.Bethesda.Analyzers.Skyrim.Record.Perk;
 public class FragmentAnalyzerPerk : IIsolatedRecordAnalyzer<IPerkGetter>
 {
     public static readonly TopicDefinition<string> DuplicateFragment = MutagenTopicBuilder.DevelopmentTopic(
-            "Duplicate fragment",
+            "Duplicate fragment perk",
             Severity.Error)
         .WithFormatting<string>("Fragment function {0} is used multiple times");
 
     public static readonly TopicDefinition EmptyFragment = MutagenTopicBuilder.DevelopmentTopic(
-            "Empty fragment script",
+            "Empty fragment perk",
             Severity.Suggestion)
-        .WithoutFormatting("Responses has script attached, but no fragments");
+        .WithoutFormatting("Perk has script attached, but no fragments");
 
     public IEnumerable<TopicDefinition> Topics => [DuplicateFragment, EmptyFragment];
 
@@ -34,8 +34,7 @@ public class FragmentAnalyzerPerk : IIsolatedRecordAnalyzer<IPerkGetter>
             FragmentAnalyzerUtil.CheckDuplicateFragments(
                 param,
                 DuplicateFragment,
-                vmad.ScriptFragments.Fragments,
-                f => f.FragmentName);
+                vmad.ScriptFragments.Fragments.Select(f => f.FragmentName));
         }
     }
 

--- a/Mutagen.Bethesda.Analyzers.Skyrim/Record/Perk/FragmentAnalyzerPerk.cs
+++ b/Mutagen.Bethesda.Analyzers.Skyrim/Record/Perk/FragmentAnalyzerPerk.cs
@@ -7,13 +7,15 @@ namespace Mutagen.Bethesda.Analyzers.Skyrim.Record.Perk;
 
 public class FragmentAnalyzerPerk : IIsolatedRecordAnalyzer<IPerkGetter>
 {
-    public static readonly TopicDefinition<string> DuplicateFragment = MutagenTopicBuilder.DevelopmentTopic(
-            "Duplicate fragment perk",
+    public static readonly TopicDefinition<string> DuplicateFragment = MutagenTopicBuilder.FromDiscussion(
+            589,
+            "Duplicate perk fragment name",
             Severity.Error)
         .WithFormatting<string>("Fragment function {0} is used multiple times");
 
-    public static readonly TopicDefinition EmptyFragment = MutagenTopicBuilder.DevelopmentTopic(
-            "Empty fragment perk",
+    public static readonly TopicDefinition EmptyFragment = MutagenTopicBuilder.FromDiscussion(
+            590,
+            "Empty perk fragment script",
             Severity.Suggestion)
         .WithoutFormatting("Perk has script attached, but no fragments");
 

--- a/Mutagen.Bethesda.Analyzers.Skyrim/Record/Quest/FragmentAnalyzerQuest.cs
+++ b/Mutagen.Bethesda.Analyzers.Skyrim/Record/Quest/FragmentAnalyzerQuest.cs
@@ -3,7 +3,6 @@ using Mutagen.Bethesda.Analyzers.SDK.Analyzers;
 using Mutagen.Bethesda.Analyzers.SDK.Topics;
 using Mutagen.Bethesda.Analyzers.Skyrim.Util;
 using Mutagen.Bethesda.Skyrim;
-using Noggog;
 
 namespace Mutagen.Bethesda.Analyzers.Skyrim.Record.Quest;
 
@@ -13,12 +12,12 @@ public partial class FragmentAnalyzerQuest : IIsolatedRecordAnalyzer<IQuestGette
     private static partial Regex FragmentRegex { get; }
 
     public static readonly TopicDefinition<string> DuplicateFragment = MutagenTopicBuilder.DevelopmentTopic(
-            "Duplicate fragment",
+            "Duplicate fragment quest",
             Severity.Error)
         .WithFormatting<string>("Fragment function {0} is used multiple times");
 
     public static readonly TopicDefinition<string> EmptyFragment = MutagenTopicBuilder.DevelopmentTopic(
-            "Empty fragment script",
+            "Empty fragment quest",
             Severity.Suggestion)
         .WithFormatting<string>("Quest has empty fragment script {0}");
 
@@ -41,8 +40,7 @@ public partial class FragmentAnalyzerQuest : IIsolatedRecordAnalyzer<IQuestGette
         FragmentAnalyzerUtil.CheckDuplicateFragments(
             param,
             DuplicateFragment,
-            vmad.Fragments,
-            f => f.FragmentName);
+            vmad.Fragments.Select(f => f.FragmentName));
 
         if (vmad.Fragments.Count == 0)
         {

--- a/Mutagen.Bethesda.Analyzers.Skyrim/Record/Quest/FragmentAnalyzerQuest.cs
+++ b/Mutagen.Bethesda.Analyzers.Skyrim/Record/Quest/FragmentAnalyzerQuest.cs
@@ -11,13 +11,15 @@ public partial class FragmentAnalyzerQuest : IIsolatedRecordAnalyzer<IQuestGette
     [GeneratedRegex(@"^([A-Z0-9]{1,4}_)?QF_", RegexOptions.IgnoreCase)]
     private static partial Regex FragmentRegex { get; }
 
-    public static readonly TopicDefinition<string> DuplicateFragment = MutagenTopicBuilder.DevelopmentTopic(
-            "Duplicate fragment quest",
+    public static readonly TopicDefinition<string> DuplicateFragment = MutagenTopicBuilder.FromDiscussion(
+            584,
+            "Duplicate quest fragment name",
             Severity.Error)
         .WithFormatting<string>("Fragment function {0} is used multiple times");
 
-    public static readonly TopicDefinition<string> EmptyFragment = MutagenTopicBuilder.DevelopmentTopic(
-            "Empty fragment quest",
+    public static readonly TopicDefinition<string> EmptyFragment = MutagenTopicBuilder.FromDiscussion(
+            585,
+            "Empty quest fragment script",
             Severity.Suggestion)
         .WithFormatting<string>("Quest has empty fragment script {0}");
 

--- a/Mutagen.Bethesda.Analyzers.Skyrim/Record/Quest/FragmentAnalyzerQuest.cs
+++ b/Mutagen.Bethesda.Analyzers.Skyrim/Record/Quest/FragmentAnalyzerQuest.cs
@@ -1,0 +1,63 @@
+using System.Text.RegularExpressions;
+using Mutagen.Bethesda.Analyzers.SDK.Analyzers;
+using Mutagen.Bethesda.Analyzers.SDK.Topics;
+using Mutagen.Bethesda.Skyrim;
+using Noggog;
+
+namespace Mutagen.Bethesda.Analyzers.Skyrim.Record.Quest;
+
+public partial class FragmentAnalyzerQuest : IIsolatedRecordAnalyzer<IQuestGetter>
+{
+    [GeneratedRegex(@"^([A-Z0-9]{1,4}_)?QF_", RegexOptions.IgnoreCase)]
+    private static partial Regex FragmentRegex { get; }
+
+    public static readonly TopicDefinition<string> DuplicateFragment = MutagenTopicBuilder.DevelopmentTopic(
+            "Duplicate fragment",
+            Severity.Error)
+        .WithFormatting<string>("Fragment function {0} is used multiple times");
+
+    public static readonly TopicDefinition<string> EmptyFragment = MutagenTopicBuilder.DevelopmentTopic(
+            "Empty fragment script",
+            Severity.Suggestion)
+        .WithFormatting<string>("Quest has empty fragment script {0}");
+
+    public IEnumerable<TopicDefinition> Topics => [DuplicateFragment];
+
+    // Find the first attached script that appears to be a fragment script
+    public static string? GetFragmentScriptName(IEnumerable<IScriptEntryGetter> scripts)
+    {
+        return scripts
+            .Select(s => s.Name)
+            .FirstOrDefault(n => FragmentRegex.IsMatch(n));
+    }
+
+    public void AnalyzeRecord(IsolatedRecordAnalyzerParams<IQuestGetter> param)
+    {
+        var quest = param.Record;
+        if (quest.VirtualMachineAdapter == null)
+            return;
+
+        var duplicates = quest.VirtualMachineAdapter.Fragments
+            .GroupBy(f => f.FragmentName)
+            .Where(g => g.CountGreaterThan(1));
+
+        foreach (var dupe in duplicates)
+        {
+            param.AddTopic(DuplicateFragment.Format(dupe.Key), ("Usages", dupe));
+        }
+
+        if (quest.VirtualMachineAdapter.Fragments.Count == 0)
+        {
+            var fragment = GetFragmentScriptName(quest.VirtualMachineAdapter.Scripts);
+            if (fragment != null)
+            {
+                param.AddTopic(EmptyFragment.Format(fragment));
+            }
+        }
+    }
+
+    public IEnumerable<Func<IQuestGetter, object?>> FieldsOfInterest()
+    {
+        yield return x => x.VirtualMachineAdapter;
+    }
+}

--- a/Mutagen.Bethesda.Analyzers.Skyrim/Record/Quest/FragmentAnalyzerQuest.cs
+++ b/Mutagen.Bethesda.Analyzers.Skyrim/Record/Quest/FragmentAnalyzerQuest.cs
@@ -1,6 +1,7 @@
 using System.Text.RegularExpressions;
 using Mutagen.Bethesda.Analyzers.SDK.Analyzers;
 using Mutagen.Bethesda.Analyzers.SDK.Topics;
+using Mutagen.Bethesda.Analyzers.Skyrim.Util;
 using Mutagen.Bethesda.Skyrim;
 using Noggog;
 
@@ -21,7 +22,7 @@ public partial class FragmentAnalyzerQuest : IIsolatedRecordAnalyzer<IQuestGette
             Severity.Suggestion)
         .WithFormatting<string>("Quest has empty fragment script {0}");
 
-    public IEnumerable<TopicDefinition> Topics => [DuplicateFragment];
+    public IEnumerable<TopicDefinition> Topics => [DuplicateFragment, EmptyFragment];
 
     // Find the first attached script that appears to be a fragment script
     public static string? GetFragmentScriptName(IEnumerable<IScriptEntryGetter> scripts)
@@ -33,22 +34,19 @@ public partial class FragmentAnalyzerQuest : IIsolatedRecordAnalyzer<IQuestGette
 
     public void AnalyzeRecord(IsolatedRecordAnalyzerParams<IQuestGetter> param)
     {
-        var quest = param.Record;
-        if (quest.VirtualMachineAdapter == null)
+        var vmad = param.Record.VirtualMachineAdapter;
+        if (vmad == null)
             return;
 
-        var duplicates = quest.VirtualMachineAdapter.Fragments
-            .GroupBy(f => f.FragmentName)
-            .Where(g => g.CountGreaterThan(1));
+        FragmentAnalyzerUtil.CheckDuplicateFragments(
+            param,
+            DuplicateFragment,
+            vmad.Fragments,
+            f => f.FragmentName);
 
-        foreach (var dupe in duplicates)
+        if (vmad.Fragments.Count == 0)
         {
-            param.AddTopic(DuplicateFragment.Format(dupe.Key), ("Usages", dupe));
-        }
-
-        if (quest.VirtualMachineAdapter.Fragments.Count == 0)
-        {
-            var fragment = GetFragmentScriptName(quest.VirtualMachineAdapter.Scripts);
+            var fragment = GetFragmentScriptName(vmad.Scripts);
             if (fragment != null)
             {
                 param.AddTopic(EmptyFragment.Format(fragment));

--- a/Mutagen.Bethesda.Analyzers.Skyrim/Record/Scene/FragmentAnalyzerScene.cs
+++ b/Mutagen.Bethesda.Analyzers.Skyrim/Record/Scene/FragmentAnalyzerScene.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Mutagen.Bethesda.Analyzers.SDK.Analyzers;
+using Mutagen.Bethesda.Analyzers.SDK.Topics;
+using Mutagen.Bethesda.Analyzers.Skyrim.Util;
+using Mutagen.Bethesda.Skyrim;
+using Noggog;
+
+namespace Mutagen.Bethesda.Analyzers.Skyrim.Record.Scene;
+
+public class FragmentAnalyzerScene : IIsolatedRecordAnalyzer<ISceneGetter>
+{
+    public static readonly TopicDefinition<string> DuplicateFragment = MutagenTopicBuilder.DevelopmentTopic(
+            "Duplicate fragment",
+            Severity.Error)
+        .WithFormatting<string>("Fragment function {0} is used multiple times");
+
+    public static readonly TopicDefinition EmptyFragment = MutagenTopicBuilder.DevelopmentTopic(
+            "Empty fragment script",
+            Severity.Suggestion)
+        .WithoutFormatting("Scene has script attached, but no fragments");
+
+    public IEnumerable<TopicDefinition> Topics => [DuplicateFragment, EmptyFragment];
+
+    public void AnalyzeRecord(IsolatedRecordAnalyzerParams<ISceneGetter> param)
+    {
+        var vmad = param.Record.VirtualMachineAdapter;
+        if (vmad == null)
+            return;
+
+        if (vmad.ScriptFragments == null)
+        {
+            param.AddTopic(EmptyFragment.Format());
+        }
+        else
+        {
+            // FIXME: Also include OnBegin and OnEnd, these are a different interface, may want to do it in Mutagen directly
+            FragmentAnalyzerUtil.CheckDuplicateFragments(
+                param,
+                DuplicateFragment,
+                vmad.ScriptFragments.PhaseFragments,
+                f => f.FragmentName);
+        }
+    }
+
+    public IEnumerable<Func<ISceneGetter, object?>> FieldsOfInterest()
+    {
+        yield return x => x.VirtualMachineAdapter;
+    }
+}

--- a/Mutagen.Bethesda.Analyzers.Skyrim/Record/Scene/FragmentAnalyzerScene.cs
+++ b/Mutagen.Bethesda.Analyzers.Skyrim/Record/Scene/FragmentAnalyzerScene.cs
@@ -1,13 +1,7 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Mutagen.Bethesda.Analyzers.SDK.Analyzers;
 using Mutagen.Bethesda.Analyzers.SDK.Topics;
 using Mutagen.Bethesda.Analyzers.Skyrim.Util;
 using Mutagen.Bethesda.Skyrim;
-using Noggog;
 
 namespace Mutagen.Bethesda.Analyzers.Skyrim.Record.Scene;
 

--- a/Mutagen.Bethesda.Analyzers.Skyrim/Record/Scene/FragmentAnalyzerScene.cs
+++ b/Mutagen.Bethesda.Analyzers.Skyrim/Record/Scene/FragmentAnalyzerScene.cs
@@ -8,12 +8,12 @@ namespace Mutagen.Bethesda.Analyzers.Skyrim.Record.Scene;
 public class FragmentAnalyzerScene : IIsolatedRecordAnalyzer<ISceneGetter>
 {
     public static readonly TopicDefinition<string> DuplicateFragment = MutagenTopicBuilder.DevelopmentTopic(
-            "Duplicate fragment",
+            "Duplicate fragment scene",
             Severity.Error)
         .WithFormatting<string>("Fragment function {0} is used multiple times");
 
     public static readonly TopicDefinition EmptyFragment = MutagenTopicBuilder.DevelopmentTopic(
-            "Empty fragment script",
+            "Empty fragment scene",
             Severity.Suggestion)
         .WithoutFormatting("Scene has script attached, but no fragments");
 
@@ -31,12 +31,14 @@ public class FragmentAnalyzerScene : IIsolatedRecordAnalyzer<ISceneGetter>
         }
         else
         {
-            // FIXME: Also include OnBegin and OnEnd, these are a different interface, may want to do it in Mutagen directly
+            var names = vmad.ScriptFragments.PhaseFragments
+                .Select(f => f.FragmentName)
+                .Append(vmad.ScriptFragments.OnBegin?.FragmentName)
+                .Append(vmad.ScriptFragments.OnEnd?.FragmentName);
             FragmentAnalyzerUtil.CheckDuplicateFragments(
                 param,
                 DuplicateFragment,
-                vmad.ScriptFragments.PhaseFragments,
-                f => f.FragmentName);
+                names);
         }
     }
 

--- a/Mutagen.Bethesda.Analyzers.Skyrim/Record/Scene/FragmentAnalyzerScene.cs
+++ b/Mutagen.Bethesda.Analyzers.Skyrim/Record/Scene/FragmentAnalyzerScene.cs
@@ -7,13 +7,15 @@ namespace Mutagen.Bethesda.Analyzers.Skyrim.Record.Scene;
 
 public class FragmentAnalyzerScene : IIsolatedRecordAnalyzer<ISceneGetter>
 {
-    public static readonly TopicDefinition<string> DuplicateFragment = MutagenTopicBuilder.DevelopmentTopic(
-            "Duplicate fragment scene",
+    public static readonly TopicDefinition<string> DuplicateFragment = MutagenTopicBuilder.FromDiscussion(
+            591,
+            "Duplicate scene fragment name",
             Severity.Error)
         .WithFormatting<string>("Fragment function {0} is used multiple times");
 
-    public static readonly TopicDefinition EmptyFragment = MutagenTopicBuilder.DevelopmentTopic(
-            "Empty fragment scene",
+    public static readonly TopicDefinition EmptyFragment = MutagenTopicBuilder.FromDiscussion(
+            592,
+            "Empty scene fragment script",
             Severity.Suggestion)
         .WithoutFormatting("Scene has script attached, but no fragments");
 

--- a/Mutagen.Bethesda.Analyzers.Skyrim/Util/FragmentAnalyzerUtil.cs
+++ b/Mutagen.Bethesda.Analyzers.Skyrim/Util/FragmentAnalyzerUtil.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Mutagen.Bethesda.Analyzers.SDK.Analyzers;
+using Mutagen.Bethesda.Analyzers.SDK.Topics;
+using Mutagen.Bethesda.Plugins.Records;
+using Mutagen.Bethesda.Skyrim;
+using Noggog;
+
+namespace Mutagen.Bethesda.Analyzers.Skyrim.Util;
+public static class FragmentAnalyzerUtil
+{
+    public static void CheckDuplicateFragments<T, U>(
+        IsolatedRecordAnalyzerParams<T> param,
+        TopicDefinition<string> topic,
+        IEnumerable<U?> fragments,
+        Func<U, string> nameSelector) where T : IMajorRecordGetter where U : class
+    {
+        var duplicates = fragments
+            .WhereNotNull()
+            .GroupBy(nameSelector)
+            .Where(g => g.CountGreaterThan(1));
+
+        foreach (var dupe in duplicates)
+        {
+            param.AddTopic(topic.Format(dupe.Key), ("Usages", dupe));
+        }
+    }
+}

--- a/Mutagen.Bethesda.Analyzers.Skyrim/Util/FragmentAnalyzerUtil.cs
+++ b/Mutagen.Bethesda.Analyzers.Skyrim/Util/FragmentAnalyzerUtil.cs
@@ -6,20 +6,19 @@ using Noggog;
 namespace Mutagen.Bethesda.Analyzers.Skyrim.Util;
 public static class FragmentAnalyzerUtil
 {
-    public static void CheckDuplicateFragments<T, U>(
+    public static void CheckDuplicateFragments<T>(
         IsolatedRecordAnalyzerParams<T> param,
         TopicDefinition<string> topic,
-        IEnumerable<U?> fragments,
-        Func<U, string> nameSelector) where T : IMajorRecordGetter where U : class
+        IEnumerable<string?> fragmentNames) where T : IMajorRecordGetter
     {
-        var duplicates = fragments
+        var duplicates = fragmentNames
             .WhereNotNull()
-            .GroupBy(nameSelector, StringComparer.OrdinalIgnoreCase)
+            .GroupBy(f => f, StringComparer.OrdinalIgnoreCase)
             .Where(g => g.CountGreaterThan(1));
 
         foreach (var dupe in duplicates)
         {
-            param.AddTopic(topic.Format(dupe.Key), ("Usages", dupe));
+            param.AddTopic(topic.Format(dupe.Key));
         }
     }
 }

--- a/Mutagen.Bethesda.Analyzers.Skyrim/Util/FragmentAnalyzerUtil.cs
+++ b/Mutagen.Bethesda.Analyzers.Skyrim/Util/FragmentAnalyzerUtil.cs
@@ -1,12 +1,6 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Mutagen.Bethesda.Analyzers.SDK.Analyzers;
 using Mutagen.Bethesda.Analyzers.SDK.Topics;
 using Mutagen.Bethesda.Plugins.Records;
-using Mutagen.Bethesda.Skyrim;
 using Noggog;
 
 namespace Mutagen.Bethesda.Analyzers.Skyrim.Util;
@@ -20,7 +14,7 @@ public static class FragmentAnalyzerUtil
     {
         var duplicates = fragments
             .WhereNotNull()
-            .GroupBy(nameSelector)
+            .GroupBy(nameSelector, StringComparer.OrdinalIgnoreCase)
             .Where(g => g.CountGreaterThan(1));
 
         foreach (var dupe in duplicates)


### PR DESCRIPTION
Analysers to detect duplicate fragment function names and empty fragment scripts for dialog responses, packages, perks, quests, and scenes. Covers discussions #584, #585, #586, #587, #588, #589, #590, #591, #592, and #593