### PR TITLE
Return missing conditions from GetConditions

### DIFF
--- a/Mutagen.Bethesda.Analyzers.Skyrim/Extensions/RecordExtension.cs
+++ b/Mutagen.Bethesda.Analyzers.Skyrim/Extensions/RecordExtension.cs
@@ -1,4 +1,4 @@
-﻿using Mutagen.Bethesda.Skyrim;
+using Mutagen.Bethesda.Skyrim;
 
 namespace Mutagen.Bethesda.Analyzers.Skyrim.Extensions;
 
@@ -24,7 +24,9 @@ public static class RecordExtension
                 .Concat(quest.Aliases.SelectMany(a => a.Conditions))
                 .Concat(quest.Stages.SelectMany(s => s.LogEntries.SelectMany(e => e.Conditions)))
                 .Concat(quest.Objectives.SelectMany(o => o.Targets.SelectMany(t => t.Conditions))),
-            ISceneGetter scene => scene.Conditions,
+            ISceneGetter scene => scene.Conditions
+                .Concat(scene.Phases.SelectMany(phase => phase.StartConditions))
+                .Concat(scene.Phases.SelectMany(phase => phase.CompletionConditions)),
             ISoundDescriptorGetter soundDescriptor => soundDescriptor.Conditions,
             IAStoryManagerNodeGetter storyManagerNode => storyManagerNode.Conditions,
             _ => null

--- a/Mutagen.Bethesda.Analyzers.Skyrim/Extensions/RecordExtension.cs
+++ b/Mutagen.Bethesda.Analyzers.Skyrim/Extensions/RecordExtension.cs
@@ -17,8 +17,10 @@ public static class RecordExtension
             IMagicEffectGetter magicEffect => magicEffect.Conditions,
             IMessageGetter message => message.MenuButtons.SelectMany(x => x.Conditions),
             IMusicTrackGetter musicTrack => musicTrack.Conditions,
+            IObjectEffectGetter objectEffect => objectEffect.Effects.SelectMany(effect => effect.Conditions),
             IPackageGetter package => package.Conditions.Concat(package.ProcedureTree.SelectMany(b => b.Conditions)),
-            IPerkGetter perk => perk.Conditions,
+            IPerkGetter perk => perk.Conditions
+                .Concat(perk.Effects.SelectMany(effect => effect.Conditions.SelectMany(tab => tab.Conditions))),
             IQuestGetter quest => quest.DialogConditions
                 .Concat(quest.EventConditions)
                 .Concat(quest.Aliases.SelectMany(a => a.Conditions))
@@ -27,7 +29,9 @@ public static class RecordExtension
             ISceneGetter scene => scene.Conditions
                 .Concat(scene.Phases.SelectMany(phase => phase.StartConditions))
                 .Concat(scene.Phases.SelectMany(phase => phase.CompletionConditions)),
+            IScrollGetter scroll => scroll.Effects.SelectMany(effect => effect.Conditions),
             ISoundDescriptorGetter soundDescriptor => soundDescriptor.Conditions,
+            ISpellGetter spell => spell.Effects.SelectMany(effect => effect.Conditions),
             IAStoryManagerNodeGetter storyManagerNode => storyManagerNode.Conditions,
             _ => null
         };


### PR DESCRIPTION
Return the following missing conditions to GetConditions:
- Enchantment effects
- Perk entry points
- Scene phase begin/end
- Scroll effects
- Spell effects