### PR TITLE
ConsoleReportHandler reports EditorID of sourceMod instead of Winning EditorID of LinkCache

### DIFF
--- a/Mutagen.Bethesda.Analyzers.Engine/Reporting/Handlers/ConsoleReportHandler.cs
+++ b/Mutagen.Bethesda.Analyzers.Engine/Reporting/Handlers/ConsoleReportHandler.cs
@@ -3,6 +3,7 @@ using Mutagen.Bethesda.Analyzers.SDK.Drops;
 using Mutagen.Bethesda.Analyzers.SDK.Topics;
 using Mutagen.Bethesda.Plugins;
 using Mutagen.Bethesda.Plugins.Cache;
+using Mutagen.Bethesda.Plugins.Cache.Internals.Implementations;
 using Mutagen.Bethesda.Plugins.Records;
 using Noggog.WorkEngine;
 
@@ -33,7 +34,24 @@ public class ConsoleReportHandler : IReportHandler
         _workDropoff.Enqueue(() =>
         {
             IMajorRecordGetter? parent = null;
-            _linkCache.TryResolveIdentifier(majorRecord, out var editorId);
+            ImmutableModLinkCache? sourceModLinkCache = null;
+            string? editorId = "";
+            foreach (var modGetter in _linkCache.ListedOrder)
+            {
+                if (modGetter.ModKey == sourceMod)
+                {
+                    sourceModLinkCache = new ImmutableModLinkCache(modGetter);
+                }
+            }
+            if (sourceModLinkCache is null)
+            {
+                _linkCache.TryResolveIdentifier(majorRecord, out editorId);
+            }
+            else
+            {
+                sourceModLinkCache.TryResolveIdentifier(majorRecord, out editorId);
+            }
+
             if (_linkCache.TryResolveSimpleContext(majorRecord, out var parentContext) && parentContext?.Parent?.Record is IMajorRecordGetter parentRecord)
             {
                 parent = parentRecord;

--- a/Mutagen.Bethesda.Analyzers.Engine/Reporting/Handlers/ConsoleReportHandler.cs
+++ b/Mutagen.Bethesda.Analyzers.Engine/Reporting/Handlers/ConsoleReportHandler.cs
@@ -34,22 +34,16 @@ public class ConsoleReportHandler : IReportHandler
         _workDropoff.Enqueue(() =>
         {
             IMajorRecordGetter? parent = null;
-            ImmutableModLinkCache? sourceModLinkCache = null;
-            string? editorId = "";
-            foreach (var modGetter in _linkCache.ListedOrder)
+            var editorId = "";
+            var modGetter = _linkCache.ListedOrder.FirstOrDefault(l => l.ModKey == sourceMod);
+            if (modGetter is not null)
             {
-                if (modGetter.ModKey == sourceMod)
-                {
-                    sourceModLinkCache = new ImmutableModLinkCache(modGetter);
-                }
-            }
-            if (sourceModLinkCache is null)
-            {
-                _linkCache.TryResolveIdentifier(majorRecord, out editorId);
+                var sourceModLinkCache = new ImmutableModLinkCache(modGetter);
+                sourceModLinkCache.TryResolveIdentifier(majorRecord, out editorId);
             }
             else
             {
-                sourceModLinkCache.TryResolveIdentifier(majorRecord, out editorId);
+                _linkCache.TryResolveIdentifier(majorRecord, out editorId);
             }
 
             if (_linkCache.TryResolveSimpleContext(majorRecord, out var parentContext) && parentContext?.Parent?.Record is IMajorRecordGetter parentRecord)


### PR DESCRIPTION
ConsoleReportHandler reports EditorID of sourceMod instead of Winning EditorID of LinkCache